### PR TITLE
added QColorDialog import to be able to update the color palette

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -6,7 +6,7 @@ import sys, os, pathlib, warnings, datetime, time, copy
 
 from qtpy import QtGui, QtCore
 from superqt import QRangeSlider, QCollapsible
-from qtpy.QtWidgets import QScrollArea, QMainWindow, QApplication, QWidget, QScrollBar, QComboBox, QGridLayout, QPushButton, QFrame, QCheckBox, QLabel, QProgressBar, QLineEdit, QMessageBox, QGroupBox
+from qtpy.QtWidgets import QScrollArea, QMainWindow, QApplication, QWidget, QScrollBar, QComboBox, QGridLayout, QPushButton, QFrame, QCheckBox, QLabel, QProgressBar, QLineEdit, QMessageBox, QGroupBox, QColorDialog
 import pyqtgraph as pg
 
 import numpy as np


### PR DESCRIPTION
Resolves #4 

## imported QColorDialog
This adds an import for QColorDialog, which allows the user to pick a color.
The user can pick a color in different ways:
- of the palette
- of the screen
- a set of custom colors
- by RGB value
- by hex value
- by HSV value
The dialog window will look like this, but will adapt to your operating system (this feature can be turned off).
![fusion-colordialog](https://github.com/claassenlab/cellpose/assets/148364763/fef050f7-3f76-445a-acf1-a67e44db7094)

**Full documentation can be found at the [QT docs](https://doc.qt.io/qt-6/qcolordialog.html).**

## how to use QColorDialog

The dialog opens with `QColorDialog.getColor(parent= QWidget, initial= QColor, title= String)` and will output a QColor.
> parameters parent and title are optional, also there is a option parameter that allows to choose alpha values and other customizations (see full documentation)
The initital color is the first selected color, when the dialog starts.

### example implementation
In this example the feature is used to set the color of a button, initializing with the current button color. Parent is the QMainWindow widget (self). With `color.name()` you can retrieve the hex value.
![example-dialog-usage](https://github.com/claassenlab/cellpose/assets/148364763/4ea19d44-8e55-4675-beaf-b8a817c28916)

--- 

With this feature, issue #4 is resolved and the developer can use the color picker as desired. Unfortunately there is no option to further customize the visual appereance of the dialog window. 



