### PR TITLE
006 customize the automatically assigned colors of MARKERS

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -874,27 +874,6 @@ class MainW(QMainWindow):
             self.sliders[slider_index].setValue([0, rgb[slider_index]])
             self.update_plot()
 
-    # CHOOSE_COLOR IST UNNÖTIG FALLS ANDERE LÖSUNG RICHTI
-    def choose_color(self):
-        """
-        Opens a QColorDialog to allow the user to choose a color.
-        The selected color is then used to update the values of the three color sliders.
-
-        The QColorDialog provides a standard dialog that allows the user to select a color.
-        The selected color's RGB values are extracted and used to set the values of the red, green,
-        and blue sliders.
-
-        Returns:
-            None
-        """
-        color = QColorDialog.getColor()
-        if color.isValid():
-            rgb = color.getRgb()
-            self.sliders[0].setValue([0, rgb[0]])
-            self.sliders[1].setValue([0, rgb[1]])
-            self.sliders[2].setValue([0, rgb[2]])
-            self.update_plot()
-
     def level_change(self, r):
         r = ["red", "green", "blue"].index(r)
         if self.loaded:

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -396,14 +396,13 @@ class MainW(QMainWindow):
             self.sliders[-1].setToolTip(
                 "NOTE: manually changing the saturation bars does not affect normalization in segmentation"
             )
-            self.satBoxG.addWidget(self.sliders[-1], b0, 2, 1, 7)
+            self.satBoxG.addWidget(self.sliders[-1], b0, 2, 1, 5)
 
-        # Add "Choose Color" button below the third slider
-        b0 += 1
-        self.colorButton = QPushButton("Choose Color")
-        self.colorButton.setFont(self.medfont)
-        self.colorButton.clicked.connect(self.choose_color)
-        self.satBoxG.addWidget(self.colorButton, b0, 0, 1, 9)
+            # Add individual "Choose Color" button for each slider
+            color_button = QPushButton("Choose Color")
+            color_button.setFont(self.medfont)
+            color_button.clicked.connect(lambda _, idx=r: self.choose_slider_color(idx))
+            self.satBoxG.addWidget(color_button, b0, 7, 1, 2)
 
         b += 1
         self.drawBox = QGroupBox("Drawing")
@@ -858,6 +857,24 @@ class MainW(QMainWindow):
 
         return b
 
+    def choose_slider_color(self, slider_index):
+        """
+        Opens a QColorDialog to allow the user to choose a color for a specific slider.
+        The selected color is then used to update the value of the corresponding color slider.
+
+        Args:
+            slider_index (int): Index of the slider to update
+
+        Returns:
+            None
+        """
+        color = QColorDialog.getColor()
+        if color.isValid():
+            rgb = color.getRgb()
+            self.sliders[slider_index].setValue([0, rgb[slider_index]])
+            self.update_plot()
+
+    # CHOOSE_COLOR IST UNNÖTIG FALLS ANDERE LÖSUNG RICHTI
     def choose_color(self):
         """
         Opens a QColorDialog to allow the user to choose a color.

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -398,6 +398,7 @@ class MainW(QMainWindow):
             )
             self.satBoxG.addWidget(self.sliders[-1], b0, 2, 1, 7)
 
+        # Add "Choose Color" button below the third slider
         b0 += 1
         self.colorButton = QPushButton("Choose Color")
         self.colorButton.setFont(self.medfont)
@@ -858,6 +859,17 @@ class MainW(QMainWindow):
         return b
 
     def choose_color(self):
+        """
+        Opens a QColorDialog to allow the user to choose a color.
+        The selected color is then used to update the values of the three color sliders.
+
+        The QColorDialog provides a standard dialog that allows the user to select a color.
+        The selected color's RGB values are extracted and used to set the values of the red, green,
+        and blue sliders.
+
+        Returns:
+            None
+        """
         color = QColorDialog.getColor()
         if color.isValid():
             rgb = color.getRgb()

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -298,6 +298,9 @@ class MainW(QMainWindow):
             "model_name": "CP" + d.strftime("_%Y%m%d_%H%M%S"),
         }
 
+        b = self.make_buttons()
+        self.lmain.addWidget(self.scrollarea, 0, 0, 39, 9)
+
         self.load_3D = False
         self.stitch_threshold = 0.
 
@@ -393,8 +396,13 @@ class MainW(QMainWindow):
             self.sliders[-1].setToolTip(
                 "NOTE: manually changing the saturation bars does not affect normalization in segmentation"
             )
-            #self.sliders[-1].setTickPosition(QSlider.TicksRight)
             self.satBoxG.addWidget(self.sliders[-1], b0, 2, 1, 7)
+
+        b0 += 1
+        self.colorButton = QPushButton("Choose Color")
+        self.colorButton.setFont(self.medfont)
+        self.colorButton.clicked.connect(self.choose_color)
+        self.satBoxG.addWidget(self.colorButton, b0, 0, 1, 9)
 
         b += 1
         self.drawBox = QGroupBox("Drawing")
@@ -848,6 +856,15 @@ class MainW(QMainWindow):
         self.l0.addWidget(self.ScaleOn, b, 0, 1, 5)
 
         return b
+
+    def choose_color(self):
+        color = QColorDialog.getColor()
+        if color.isValid():
+            rgb = color.getRgb()
+            self.sliders[0].setValue([0, rgb[0]])
+            self.sliders[1].setValue([0, rgb[1]])
+            self.sliders[2].setValue([0, rgb[2]])
+            self.update_plot()
 
     def level_change(self, r):
         r = ["red", "green", "blue"].index(r)


### PR DESCRIPTION
Resolves #6

**Änderungen:**

1. **Neue Buttons:**
   - Jeweils ein neuer Button "Choose Color" wurde neben jedem der drei Farb-Slider hinzugefügt. 
   - Der Button öffnet einen QColorDialog, mit dem der Benutzer eine Farbe auswählen kann.
   - Die RGB-Werte der ausgewählten Farbe werden verwendet, um die Werte der Farb-Slider zu setzen.

2. **Neue Methode:**
   - Eine neue Methode `choose_slider_color wurde hinzugefügt, die den QColorDialog öffnet und die Slider-Werte aktualisiert.


**Testen:**
- Stelle sicher, dass die neue Buttons korrekt angezeigt wird.
- Überprüfe, ob das Farb-Auswahl-Dialogfeld geöffnet wird, wenn der Button geklickt wird.
- Wähle eine Farbe aus und stelle sicher, dass die Farb-Slider entsprechend aktualisiert werden.
- Überprüfe, ob die Anzeige korrekt aktualisiert wird, wenn die Farbe geändert wird.
