### PR TITLE
18 New menu for colour options

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -20,6 +20,8 @@ from ..io import get_image_files, imsave, imread
 from ..transforms import resize_image, normalize99, normalize99_tile, smooth_sharpen_img
 from ..models import normalize_default
 from ..plot import disk
+from PyQt5.QtWidgets import QSplitter, QHBoxLayout
+from PyQt5.QtCore import Qt
 
 try:
     import matplotlib.pyplot as plt
@@ -248,6 +250,25 @@ class MainW(QMainWindow):
         self.swidget.setLayout(self.l0)
         b = self.make_buttons()
         self.lmain.addWidget(self.scrollarea, 0, 0, 39, 9)
+
+        # ---- Right side menu layout ---- #
+        self.rightBox = QGroupBox()
+        self.rightBoxLayout = QGridLayout()
+        self.rightBox.setLayout(self.rightBoxLayout)
+
+        # --- Make the right side menu scrollable---#
+        self.rightScrollArea = QScrollArea()
+        self.rightScrollArea.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)  # scrollbar always visible
+        self.rightScrollArea.setStyleSheet("""QScrollArea { border: none }""")  # remove border
+        self.rightScrollArea.setWidgetResizable(True)  # resizing allowed
+        self.rightScrollArea.setWidget(self.rightBox)  # set the rightBox as the content of the scroll area
+
+        # --- Add right side menu to the main layout ---#
+        self.lmain.addWidget(self.rightScrollArea, 0, 40, 39, 9)  # Set the same row and column spans as the left side menu
+
+        # Get the width of the left side menu and set to right side menu width
+        leftMenuWidth = self.scrollarea.sizeHint().width()
+        self.rightScrollArea.setFixedWidth(leftMenuWidth)
 
         # ---- drawing area ---- #
         self.win = pg.GraphicsLayoutWidget()

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -264,9 +264,6 @@ class MainW(QMainWindow):
         # --- Add right side menu to the main layout ---#
         self.lmain.addWidget(self.rightScrollArea, 0, 40, 39, 9)  # Set the same row and column spans as the left side menu
 
-        # Get the width of the left side menu and set to right side menu width
-        leftMenuWidth = self.scrollarea.sizeHint().width()
-        self.rightScrollArea.setFixedWidth(leftMenuWidth)
 
         # ---- drawing area ---- #
         self.win = pg.GraphicsLayoutWidget()

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -20,8 +20,6 @@ from ..io import get_image_files, imsave, imread
 from ..transforms import resize_image, normalize99, normalize99_tile, smooth_sharpen_img
 from ..models import normalize_default
 from ..plot import disk
-from PyQt5.QtWidgets import QSplitter, QHBoxLayout
-from PyQt5.QtCore import Qt
 
 try:
     import matplotlib.pyplot as plt


### PR DESCRIPTION
Solves #18

This PR addresses the user story of adding a separate menu on the right side of the Cellpose GUI. The goal is to provide more space for the colour saturation sliders in the future.

Changes made:
1. Added a new menu on the right side of the GUI. This menu matches the width and height of the existing left side menu.
2. Made the right side menu scrollable, similar to the left side menu.
3. Ensured that the right side menu resizes with the window, maintaining its width relative to the left side menu.

Changes were only made in the gui.py file.