### PR TITLE
The colour sliders are on the right hand side now

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -411,7 +411,7 @@ class MainW(QMainWindow):
             self.sliders[-1].setToolTip(
                 "NOTE: manually changing the saturation bars does not affect normalization in segmentation"
             )
-            self.sliders[-1].setFixedWidth(250)
+            self.sliders[-1].setFixedWidth(160)
             self.rightBoxLayout.addWidget(self.sliders[-1], c, 2, 1, 7)
             stretch_widget = QWidget()
             self.rightBoxLayout.addWidget(stretch_widget)
@@ -1690,7 +1690,7 @@ class MainW(QMainWindow):
     def update_layer(self):
         if self.masksOn or self.outlinesOn:
             #self.draw_layer()
-            self.layer.setImage(self.layerz, autoLevels=False)    
+            self.layer.setImage(self.layerz, autoLevels=False)
         self.update_roi_count()
         self.win.show()
         self.show()
@@ -1980,7 +1980,7 @@ class MainW(QMainWindow):
             normalize_params["tile_norm_smooth3D"] = smooth3D
             normalize_params["norm3D"] = norm3D
             normalize_params["invert"] = invert
-        
+
         from cellpose.models import normalize_default
         normalize_params = {**normalize_default, **normalize_params}
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -4,6 +4,7 @@ Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer a
 
 import sys, os, pathlib, warnings, datetime, time, copy
 
+from PyQt5.QtWidgets import QLabel, QSlider, QVBoxLayout, QWidget
 from qtpy import QtGui, QtCore
 from superqt import QRangeSlider, QCollapsible
 from qtpy.QtWidgets import QScrollArea, QMainWindow, QApplication, QWidget, QScrollBar, QComboBox, QGridLayout, QPushButton, QFrame, QCheckBox, QLabel, QProgressBar, QLineEdit, QMessageBox, QGroupBox, QColorDialog
@@ -246,7 +247,7 @@ class MainW(QMainWindow):
         self.scrollarea.setWidget(self.swidget)
         self.l0 = QGridLayout()
         self.swidget.setLayout(self.l0)
-        b = self.make_buttons()
+        #b = self.make_buttons() was here
         self.lmain.addWidget(self.scrollarea, 0, 0, 39, 9)
 
         # ---- Right side menu layout ---- #
@@ -262,8 +263,10 @@ class MainW(QMainWindow):
         self.rightScrollArea.setWidget(self.rightBox)  # set the rightBox as the content of the scroll area
 
         # --- Add right side menu to the main layout ---#
-        self.lmain.addWidget(self.rightScrollArea, 0, 40, 39, 9)  # Set the same row and column spans as the left side menu
+        self.lmain.addWidget(self.rightScrollArea, 0, 40, 39,
+                             9)  # Set the same row and column spans as the left side menu
 
+        b = self.make_buttons()
 
         # ---- drawing area ---- #
         self.win = pg.GraphicsLayoutWidget()
@@ -388,20 +391,21 @@ class MainW(QMainWindow):
         self.autobtn.setChecked(True)
         self.satBoxG.addWidget(self.autobtn, b0, 1, 1, 8)
 
-        b0 += 1
+        c = 0  # position of the elements in the right side menu
+
         self.sliders = []
         colors = [[255, 0, 0], [0, 255, 0], [0, 0, 255], [100, 100, 100]]
         colornames = ["red", "Chartreuse", "DodgerBlue"]
         names = ["red", "green", "blue"]
-        for r in range(3):
-            b0 += 1
+        for r in range(3):  # changed to right box and to variable c
+            c += 1
             if r == 0:
                 label = QLabel('<font color="gray">gray/</font><br>red')
             else:
                 label = QLabel(names[r] + ":")
             label.setStyleSheet(f"color: {colornames[r]}")
             label.setFont(self.boldmedfont)
-            self.satBoxG.addWidget(label, b0, 0, 1, 2)
+            self.rightBoxLayout.addWidget(label, c, 0, 1, 2)  # changed to rightBox
             self.sliders.append(Slider(self, names[r], colors[r]))
             self.sliders[-1].setMinimum(-.1)
             self.sliders[-1].setMaximum(255.1)
@@ -409,8 +413,11 @@ class MainW(QMainWindow):
             self.sliders[-1].setToolTip(
                 "NOTE: manually changing the saturation bars does not affect normalization in segmentation"
             )
-            #self.sliders[-1].setTickPosition(QSlider.TicksRight)
-            self.satBoxG.addWidget(self.sliders[-1], b0, 2, 1, 7)
+            # self.sliders[-1].setTickPosition(QSlider.TicksRight)
+            self.rightBoxLayout.addWidget(self.sliders[-1], c, 2, 1, 7)  # changed to right box
+            stretch_widget = QWidget()
+            self.rightBoxLayout.addWidget(stretch_widget)
+
 
         b += 1
         self.drawBox = QGroupBox("Drawing")

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -4,7 +4,6 @@ Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer a
 
 import sys, os, pathlib, warnings, datetime, time, copy
 
-from PyQt5.QtWidgets import QLabel, QSlider, QVBoxLayout, QWidget
 from qtpy import QtGui, QtCore
 from superqt import QRangeSlider, QCollapsible
 from qtpy.QtWidgets import QScrollArea, QMainWindow, QApplication, QWidget, QScrollBar, QComboBox, QGridLayout, QPushButton, QFrame, QCheckBox, QLabel, QProgressBar, QLineEdit, QMessageBox, QGroupBox, QColorDialog
@@ -247,7 +246,6 @@ class MainW(QMainWindow):
         self.scrollarea.setWidget(self.swidget)
         self.l0 = QGridLayout()
         self.swidget.setLayout(self.l0)
-        #b = self.make_buttons() was here
         self.lmain.addWidget(self.scrollarea, 0, 0, 39, 9)
 
         # ---- Right side menu layout ---- #
@@ -397,7 +395,7 @@ class MainW(QMainWindow):
         colors = [[255, 0, 0], [0, 255, 0], [0, 0, 255], [100, 100, 100]]
         colornames = ["red", "Chartreuse", "DodgerBlue"]
         names = ["red", "green", "blue"]
-        for r in range(3):  # changed to right box and to variable c
+        for r in range(3):
             c += 1
             if r == 0:
                 label = QLabel('<font color="gray">gray/</font><br>red')
@@ -405,7 +403,7 @@ class MainW(QMainWindow):
                 label = QLabel(names[r] + ":")
             label.setStyleSheet(f"color: {colornames[r]}")
             label.setFont(self.boldmedfont)
-            self.rightBoxLayout.addWidget(label, c, 0, 1, 2)  # changed to rightBox
+            self.rightBoxLayout.addWidget(label, c, 0, 1, 2)
             self.sliders.append(Slider(self, names[r], colors[r]))
             self.sliders[-1].setMinimum(-.1)
             self.sliders[-1].setMaximum(255.1)
@@ -413,8 +411,8 @@ class MainW(QMainWindow):
             self.sliders[-1].setToolTip(
                 "NOTE: manually changing the saturation bars does not affect normalization in segmentation"
             )
-            # self.sliders[-1].setTickPosition(QSlider.TicksRight)
-            self.rightBoxLayout.addWidget(self.sliders[-1], c, 2, 1, 7)  # changed to right box
+            self.sliders[-1].setFixedWidth(250)
+            self.rightBoxLayout.addWidget(self.sliders[-1], c, 2, 1, 7)
             stretch_widget = QWidget()
             self.rightBoxLayout.addWidget(stretch_widget)
 


### PR DESCRIPTION
We moved the color sliders to the right-hand side, as requested in #19. To accomplish this, we 
- relocated them from the left-hand side 
- to the right-hand side 
- and adjusted the formatting to ensure there are no leftover spaces.