### PR TITLE
20 Colour assuming buttons next to sliders

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -246,7 +246,6 @@ class MainW(QMainWindow):
         self.scrollarea.setWidget(self.swidget)
         self.l0 = QGridLayout()
         self.swidget.setLayout(self.l0)
-        b = self.make_buttons()
         self.lmain.addWidget(self.scrollarea, 0, 0, 39, 9)
 
         # ---- Right side menu layout ---- #
@@ -263,7 +262,7 @@ class MainW(QMainWindow):
 
         # --- Add right side menu to the main layout ---#
         self.lmain.addWidget(self.rightScrollArea, 0, 40, 39, 9)  # Set the same row and column spans as the left side menu
-
+        b = self.make_buttons()
 
         # ---- drawing area ---- #
         self.win = pg.GraphicsLayoutWidget()
@@ -388,27 +387,22 @@ class MainW(QMainWindow):
         self.autobtn.setChecked(True)
         self.satBoxG.addWidget(self.autobtn, b0, 1, 1, 8)
 
-        # ---create buttons ---#
-        #self.marker1_button = self.create_color_button()
-        #self.marker2_button = self.create_color_button()
-        #self.marker3_button = self.create_color_button()
-
         # ---Create a list (extendable) of color buttons  ---#
         self.marker_buttons = [self.create_color_button() for _ in range(3)]
 
-        b0 += 1
+        c = 0
         self.sliders = []
         colors = [[255, 0, 0], [0, 255, 0], [0, 0, 255], [100, 100, 100]]
         colornames = ["red", "Chartreuse", "DodgerBlue"]
         names = ["red", "green", "blue"]
         for r in range(3):
-            b0 += 1
+            c += 1
             label = QLabel(f'Marker {r+1}') # create a label for each marker
             color_button = self.marker_buttons[r] # get the corresponding color button
             label.setStyleSheet("color: white")
             label.setFont(self.boldmedfont)
-            self.satBoxG.addWidget(label, b0, 0, 1, 1) 
-            self.satBoxG.addWidget(color_button, b0, 9, 1, 1) # add the color button to the layout
+            self.rightBoxLayout.addWidget(label, c, 0, 1, 1) 
+            self.rightBoxLayout.addWidget(color_button, c, 9, 1, 1) # add the color button to the layout
             self.sliders.append(Slider(self, names[r], colors[r]))
             self.sliders[-1].setMinimum(-.1)
             self.sliders[-1].setMaximum(255.1)
@@ -416,8 +410,10 @@ class MainW(QMainWindow):
             self.sliders[-1].setToolTip(
                 "NOTE: manually changing the saturation bars does not affect normalization in segmentation"
             )
-            #self.sliders[-1].setTickPosition(QSlider.TicksRight)
-            self.satBoxG.addWidget(self.sliders[-1], b0, 2, 1, 7)
+            self.sliders[-1].setFixedWidth(250)
+            self.rightBoxLayout.addWidget(self.sliders[-1], c, 2, 1, 7)
+            stretch_widget = QWidget()
+            self.rightBoxLayout.addWidget(stretch_widget)
 
         b += 1
         self.drawBox = QGroupBox("Drawing")

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -388,6 +388,14 @@ class MainW(QMainWindow):
         self.autobtn.setChecked(True)
         self.satBoxG.addWidget(self.autobtn, b0, 1, 1, 8)
 
+        # ---create buttons ---#
+        #self.marker1_button = self.create_color_button()
+        #self.marker2_button = self.create_color_button()
+        #self.marker3_button = self.create_color_button()
+
+        # ---Create a list (extendable) of color buttons  ---#
+        self.marker_buttons = [self.create_color_button() for _ in range(3)]
+
         b0 += 1
         self.sliders = []
         colors = [[255, 0, 0], [0, 255, 0], [0, 0, 255], [100, 100, 100]]
@@ -395,13 +403,12 @@ class MainW(QMainWindow):
         names = ["red", "green", "blue"]
         for r in range(3):
             b0 += 1
-            if r == 0:
-                label = QLabel('<font color="gray">gray/</font><br>red')
-            else:
-                label = QLabel(names[r] + ":")
-            label.setStyleSheet(f"color: {colornames[r]}")
+            label = QLabel(f'Marker {r+1}') # create a label for each marker
+            color_button = self.marker_buttons[r] # get the corresponding color button
+            label.setStyleSheet("color: white")
             label.setFont(self.boldmedfont)
-            self.satBoxG.addWidget(label, b0, 0, 1, 2)
+            self.satBoxG.addWidget(label, b0, 0, 1, 1) 
+            self.satBoxG.addWidget(color_button, b0, 9, 1, 1) # add the color button to the layout
             self.sliders.append(Slider(self, names[r], colors[r]))
             self.sliders[-1].setMinimum(-.1)
             self.sliders[-1].setMaximum(255.1)
@@ -864,6 +871,51 @@ class MainW(QMainWindow):
         self.l0.addWidget(self.ScaleOn, b, 0, 1, 5)
 
         return b
+    
+    def create_color_button(self):
+        """
+        Creates a new QPushButton with a transparent background color and connects 
+        its clicked signal to the open_color_dialog method.
+
+        Returns:
+            QPushButton: The created color button.
+        """
+        color_button = QPushButton()
+        color_button.setStyleSheet(self.get_color_button_style("transparent"))
+
+        #--- Connect the button's clicked signal to a new slot method ---#
+        color_button.clicked.connect(self.open_color_dialog)
+
+        return color_button
+
+    def open_color_dialog(self):
+        """
+        Opens a QColorDialog and updates the background color of the button 
+        that was clicked (the sender of the signal) if a valid color is selected.
+        """
+        color = QColorDialog.getColor()
+        if color.isValid():
+            self.sender().setStyleSheet(self.get_color_button_style(color.name()))
+
+    def get_color_button_style(self, color_name):
+        """
+        Returns a string with the CSS style for a QPushButton with the specified background color, a solid border, a border width of 1 pixel, and a size of 12x12 pixels.
+
+        Args:
+            color_name (str): The name of the color to use for the button's background.
+
+        Returns:
+            str: The CSS style for the button.
+        """
+        return f"""
+            QPushButton {{
+                background-color: {color_name};
+                border-style: solid;
+                border-width: 1px;
+                height: 12px;
+                width: 12px;
+                }}
+            """
 
     def level_change(self, r):
         r = ["red", "green", "blue"].index(r)


### PR DESCRIPTION
Resolves #20 

This pull request addresses the issue of providing coloured buttons next to colour sliders, allowing users to assign colours manually.
#### Summary of Changes:

1. **New ColorButton Class:**
   - **Method `get_color_button_style`:** Returns a CSS style string for a `QPushButton` .
   - **Method `open_color_dialog`:** Opens a `QColorDialog` and updates the button's background colour (if a valid colour is selected).

2. **Dialog Initialization:**
   - In the `__init__` method of the `QDialog` class, a list of `ColorButton` instances is created for each marker (e.g., "marker1", "marker2", "marker3").
   - These buttons are added to the `RGBLayout` layout next to their respective sliders.

3. **Colour Updating:**
   - The `changeRGB` method is updated to call a new method, `update_color`, which updates the colour of the corresponding `ColorButton` instance when the colour is changed.

### UI Layout:

A small rectangular, coloured button is placed next to each slider on the right.
The old "red", "green", "blue", "gray/red" labels are removed and instead replaced with Marker 1, Marker 2 and Marker 3 labels.

### Extendability:
The implementation is designed to be extendable, allowing for easy addition of new colour buttons and labels without hardcoding.
