### PR TITLE
added initial color to color dialog buttons

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -878,6 +878,15 @@ class MainW(QMainWindow):
         return b
 
     def create_color_button(self, color):
+        """
+            Creates and initializes all the buttons and UI elements used in the GUI.
+            This includes buttons for changing views, drawing, segmentation, model
+            selection, and image restoration. Also initializes color buttons with
+            specific colors (red, green, blue) and on-off buttons.
+
+            Returns:
+                int: The number of buttons and UI elements created.
+            """
         color_button = QPushButton()
         color_button.setStyleSheet(self.get_color_button_style(color))
         color_button.clicked.connect(self.open_color_dialog)

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -396,7 +396,7 @@ class MainW(QMainWindow):
         # ---Create a list (extendable) of color/on-off buttons  ---#
         colors = ["red", "green", "blue"]
         self.marker_buttons = [self.create_color_button(color) for color in colors]
-        self.on_off_buttons = [self.create_on_off_button() for _ in range(3)]
+        self.on_off_buttons = [self.create_on_off_button() for color in colors]
 
         for r in range(3):
             c += 1

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -392,12 +392,11 @@ class MainW(QMainWindow):
     
         c = 0  # position of the elements in the right side menu
 
-        # ---Create a list (extendable) of color buttons  ---#
+        self.sliders = []
+        # ---Create a list (extendable) of color/on-off buttons  ---#
         colors = ["red", "green", "blue"]
         self.marker_buttons = [self.create_color_button(color) for color in colors]
-
         self.on_off_buttons = [self.create_on_off_button() for _ in range(3)]
-        self.sliders = []
 
         for r in range(3):
             c += 1
@@ -418,16 +417,11 @@ class MainW(QMainWindow):
             self.sliders[-1].setToolTip(
                 "NOTE: manually changing the saturation bars does not affect normalization in segmentation"
             )
-            # ---Create a list (extendable) of color buttons  ---#
-            colors = ["red", "green", "blue"]
-            self.marker_buttons = [self.create_color_button(color) for color in colors]
 
             self.sliders[-1].setFixedWidth(250)
             self.rightBoxLayout.addWidget(self.sliders[-1], c, 2, 1, 7)
             stretch_widget = QWidget()
             self.rightBoxLayout.addWidget(stretch_widget)
-
-
 
 
         b += 1
@@ -884,16 +878,6 @@ class MainW(QMainWindow):
         return b
 
     def create_color_button(self, color):
-        """
-            Creates a new QPushButton with a specified background color and connects
-            its clicked signal to the open_color_dialog method.
-
-            Args:
-                color (str): The initial background color of the button.
-
-            Returns:
-                QPushButton: The created color button.
-            """
         color_button = QPushButton()
         color_button.setStyleSheet(self.get_color_button_style(color))
         color_button.clicked.connect(self.open_color_dialog)

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -884,6 +884,16 @@ class MainW(QMainWindow):
         return b
 
     def create_color_button(self, color):
+        """
+            Creates a new QPushButton with a specified background color and connects
+            its clicked signal to the open_color_dialog method.
+
+            Args:
+                color (str): The initial background color of the button.
+
+            Returns:
+                QPushButton: The created color button.
+            """
         color_button = QPushButton()
         color_button.setStyleSheet(self.get_color_button_style(color))
         color_button.clicked.connect(self.open_color_dialog)

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -389,35 +389,38 @@ class MainW(QMainWindow):
         self.autobtn.setChecked(True)
         self.satBoxG.addWidget(self.autobtn, b0, 1, 1, 8)
 
-
-        # ---Create a list (extendable) of color buttons  ---#
-        self.marker_buttons = [self.create_color_button() for _ in range(3)]
-        self.on_off_buttons = [self.create_on_off_button() for _ in range(3)]
     
         c = 0  # position of the elements in the right side menu
 
+        # ---Create a list (extendable) of color buttons  ---#
+        colors = ["red", "green", "blue"]
+        self.marker_buttons = [self.create_color_button(color) for color in colors]
+
+        self.on_off_buttons = [self.create_on_off_button() for _ in range(3)]
         self.sliders = []
-        colors = [[255, 0, 0], [0, 255, 0], [0, 0, 255], [100, 100, 100]]
-        colornames = ["red", "Chartreuse", "DodgerBlue"]
-        names = ["red", "green", "blue"]
+
         for r in range(3):
             c += 1
 
             label = QLabel(f'Marker {r + 1}')  # create a label for each marker
             color_button = self.marker_buttons[r]  # get the corresponding color button
+            self.marker_buttons = [self.create_color_button(color) for color in colors]
             on_off_button = self.on_off_buttons[r]  # get the corresponding on-off button
             label.setStyleSheet("color: white")
             label.setFont(self.boldmedfont)
             self.rightBoxLayout.addWidget(label, c, 0, 1, 1)
             self.rightBoxLayout.addWidget(color_button, c, 9, 1, 1)  # add the color button to the layout
             self.rightBoxLayout.addWidget(on_off_button, c, 10, 1, 1)  # add the on-off button to the layout
-            self.sliders.append(Slider(self, names[r], colors[r]))
+            self.sliders.append(Slider(self, colors[r], None))
             self.sliders[-1].setMinimum(-.1)
             self.sliders[-1].setMaximum(255.1)
             self.sliders[-1].setValue([0, 255])
             self.sliders[-1].setToolTip(
                 "NOTE: manually changing the saturation bars does not affect normalization in segmentation"
             )
+            # ---Create a list (extendable) of color buttons  ---#
+            colors = ["red", "green", "blue"]
+            self.marker_buttons = [self.create_color_button(color) for color in colors]
 
             self.sliders[-1].setFixedWidth(250)
             self.rightBoxLayout.addWidget(self.sliders[-1], c, 2, 1, 7)
@@ -879,21 +882,11 @@ class MainW(QMainWindow):
         self.l0.addWidget(self.ScaleOn, b, 0, 1, 5)
 
         return b
-    
-    def create_color_button(self):
-        """
-        Creates a new QPushButton with a transparent background color and connects 
-        its clicked signal to the open_color_dialog method.
 
-        Returns:
-            QPushButton: The created color button.
-        """
+    def create_color_button(self, color):
         color_button = QPushButton()
-        color_button.setStyleSheet(self.get_color_button_style("transparent"))
-
-        #--- Connect the button's clicked signal to a new slot method ---#
+        color_button.setStyleSheet(self.get_color_button_style(color))
         color_button.clicked.connect(self.open_color_dialog)
-
         return color_button
 
     def create_on_off_button(self):

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -924,9 +924,20 @@ class MainW(QMainWindow):
         Opens a QColorDialog and updates the background color of the button 
         that was clicked (the sender of the signal) if a valid color is selected.
         """
-        color = QColorDialog.getColor()
-        if color.isValid():
-            self.sender().setStyleSheet(self.get_color_button_style(color.name()))
+        # Get the current color of the sender button
+        current_color = self.sender().palette().button().color()
+
+        # Create a QColorDialog instance
+        color_dialog = QColorDialog()
+
+        # Set the current color of the dialog
+        color_dialog.setCurrentColor(current_color)
+
+        # Execute the dialog and check if a valid color is selected
+        if color_dialog.exec_():
+            color = color_dialog.selectedColor()
+            if color.isValid():
+                self.sender().setStyleSheet(self.get_color_button_style(color.name()))
 
     def get_color_button_style(self, color_name):
         """


### PR DESCRIPTION

resolves #25 

Die Buttons haben jetzt initial die Farben Rot, Grün und Blau. Hierfür werden die Werte beim initialisieren der Buttons gesetzt.

Die Arrays colorsnames und names waren m.M.n. unnötig, deshalb habe ich sie gelöscht. 

create_color_button erwartet jetzt zusätzlich ein Color-Argument, später können wir da dann einfach zufällige farben übergeben für die zusätzlichen slider.