### PR TITLE
Adds new workflow that checks whether new PR's are too big and assigns size labels

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,34 @@
+name: size-label
+on: pull_request
+jobs:
+  PRSizeLabeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    outputs:
+      sizeLabel: ${{ steps.label.outputs.sizeLabel }}
+    steps:
+      - name: size-label
+        id: label
+        uses: "pascalgn/size-label-action@v0.5.2"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "5": "S",
+              "15": "M",
+              "25": "L",
+              "35": "XL",
+              "50": "Too_Big"
+            }
+  TooBig:
+    runs-on: ubuntu-latest
+    needs: PRSizeLabeler
+    if: ${{ contains(needs.PRSizeLabeler.outputs.sizeLabel, 'Too_Big') }}
+    steps:
+      - run: |
+          echo "Size is above 50, failing the workflow"
+          exit 1

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -22,7 +22,8 @@ jobs:
               "15": "M",
               "25": "L",
               "35": "XL",
-              "50": "Too_Big"
+              "50": "XXL",
+              "80": "Too_Big"
             }
   TooBig:
     runs-on: ubuntu-latest
@@ -30,5 +31,5 @@ jobs:
     if: ${{ contains(needs.PRSizeLabeler.outputs.sizeLabel, 'Too_Big') }}
     steps:
       - run: |
-          echo "Size is above 50, failing the workflow"
+          echo "The PR is too big, nobody can review something like that please split it into multiple PR's"
           exit 1

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -31,5 +31,5 @@ jobs:
     if: ${{ contains(needs.PRSizeLabeler.outputs.sizeLabel, 'Too_Big') }}
     steps:
       - run: |
-          echo "The PR is too big, nobody can review something like that please split it into multiple PR's"
+          echo "The PR is too big, nobody can review something like that. Please split it into multiple PR's"
           exit 1


### PR DESCRIPTION
Resolves #37 

Adds a new workflow so that the size of the commits are still reviewable for everyone,   
it tries to achieve that by assigning size labels to the PR's which show what size the PR is, in the shape XS-XL   
and if the PR is above 80 lines it will fail to ensure that the people really review every single line instead of just writing LGTM