### PR TITLE
34_new_settings_export_option_in_file_menue

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1158,6 +1158,7 @@ class MainW(QMainWindow):
         self.saveFlows.setEnabled(False)
         self.saveOutlines.setEnabled(False)
         self.saveROIs.setEnabled(False)
+        self.saveSettings.setEnabled(False)
 
         self.MakeDeletionRegionButton.setEnabled(False)
         self.DeleteMultipleROIButton.setEnabled(False)
@@ -1176,12 +1177,14 @@ class MainW(QMainWindow):
             self.saveFlows.setEnabled(True)
             self.saveOutlines.setEnabled(True)
             self.saveROIs.setEnabled(True)
+            self.saveSettings.setEnabled(True)
         else:
             self.saveSet.setEnabled(False)
             self.savePNG.setEnabled(False)
             self.saveFlows.setEnabled(False)
             self.saveOutlines.setEnabled(False)
             self.saveROIs.setEnabled(False)
+            self.saveSettings.setEnabled(False)
 
     def toggle_removals(self):
         if self.ncells > 0:

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1158,7 +1158,6 @@ class MainW(QMainWindow):
         self.saveFlows.setEnabled(False)
         self.saveOutlines.setEnabled(False)
         self.saveROIs.setEnabled(False)
-        self.saveSettings.setEnabled(False)
 
         self.MakeDeletionRegionButton.setEnabled(False)
         self.DeleteMultipleROIButton.setEnabled(False)
@@ -1177,14 +1176,12 @@ class MainW(QMainWindow):
             self.saveFlows.setEnabled(True)
             self.saveOutlines.setEnabled(True)
             self.saveROIs.setEnabled(True)
-            self.saveSettings.setEnabled(True)
         else:
             self.saveSet.setEnabled(False)
             self.savePNG.setEnabled(False)
             self.saveFlows.setEnabled(False)
             self.saveOutlines.setEnabled(False)
             self.saveROIs.setEnabled(False)
-            self.saveSettings.setEnabled(False)
 
     def toggle_removals(self):
         if self.ncells > 0:

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -10,7 +10,7 @@ import tifffile
 import logging
 import fastremap
 
-from ..io import imread, imsave, outlines_to_text, add_model, remove_model, save_rois
+from ..io import imread, imsave, outlines_to_text, add_model, remove_model, save_rois, save_settings
 from ..models import normalize_default, MODEL_DIR, MODEL_LIST_PATH, get_user_models
 from ..utils import masks_to_outlines, outlines_list
 
@@ -603,6 +603,15 @@ def _save_outlines(parent):
     else:
         print("ERROR: cannot save 3D outlines")
 
+def _save_settings(parent):
+    """ save settings to json file"""
+    filename = parent.filename
+    base = os.path.splitext(filename)[0]
+    if parent.NZ == 1:
+        print("GUI_INFO: saving Settings to json file")
+        save_settings(parent.filename)
+    else:
+        print("ERROR: cannot save settings")
 
 def _save_sets_with_check(parent):
     """ Save masks and update *_seg.npy file. Use this function when saving should be optional

--- a/cellpose/gui/menus.py
+++ b/cellpose/gui/menus.py
@@ -69,6 +69,12 @@ def mainmenu(parent):
     file_menu.addAction(parent.saveFlows)
     parent.saveFlows.setEnabled(False)
 
+    parent.saveSettings = QAction("Save Settings as .&json", parent)
+    parent.saveSettings.setShortcut("Ctrl+J")
+    parent.saveSettings.triggered.connect(lambda: io._save_settings(parent))
+    file_menu.addAction(parent.saveSettings)
+    parent.saveSettings.setEnabled(False)
+
 def editmenu(parent):
     main_menu = parent.menuBar()
     edit_menu = main_menu.addMenu("&Edit")

--- a/cellpose/gui/menus.py
+++ b/cellpose/gui/menus.py
@@ -73,7 +73,7 @@ def mainmenu(parent):
     parent.saveSettings.setShortcut("Ctrl+J")
     parent.saveSettings.triggered.connect(lambda: io._save_settings(parent))
     file_menu.addAction(parent.saveSettings)
-    parent.saveSettings.setEnabled(False)
+    parent.saveSettings.setEnabled(True)
 
 def editmenu(parent):
     main_menu = parent.menuBar()

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -1,7 +1,7 @@
 """
 Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer and Marius Pachitariu.
 """
-
+import json
 import os, datetime, gc, warnings, glob, shutil
 from natsort import natsorted
 import numpy as np
@@ -590,7 +590,20 @@ def save_rois(masks, file_name):
 
     roiwrite(file_name, rois)
 
+def save_settings(file_name):
+    """ save settings to .json file and remove if it already exists
 
+    Args:
+        file_name (str): name to save the .json file to
+
+    Returns:
+        None
+    """
+    file_name = os.path.splitext(file_name)[0] + "_cp_settings.json"
+    if os.path.exists(file_name):
+        os.remove(file_name)
+    with open(file_name, 'w') as f:
+        json.dump({}, f)
 
 def save_masks(images, masks, flows, file_names, png=True, tif=False, channels=[0, 0],
                suffix="", save_flows=False, save_outlines=False, 


### PR DESCRIPTION
Ich habe #34 gelöst, indem ich den neuen Menüpunkt "Save Features as .json" hinzugefügt habe und ihn so eingestellt habe, dass er wie die anderen Speicheroptionen nur klickbar ist, wenn ein Bild geladen und verändert wurde(was ich aber auch leicht ändern kann oder an eine andere Bedingung knüpfen kann, falls erforderlich). Wenn diese Bedingungen erfüllt sind und die Option ausgewählt wird, wird ein leeres json-File mit dem Namen "parent.filename_cp_settings.json" abgespeichert, wobei parent.filename der Name der gerade geladenen Abbildung ist. Außerdem wird, wenn eine vorherige Version des json-Files existiert, diese durch das neue ersetzt.