### PR TITLE
30 new export option .csv

### DIFF
--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -561,8 +561,13 @@ def _save_features_csv(parent):
     Args:
         parent: GUI object with filename and NZ attributes.
     """
+    
+    if not parent.filename:
+        raise FileNotFoundError("ERROR: No file loaded. Please load a file before attempting to save features.")
+
     filename = parent.filename
     base = os.path.splitext(filename)[0] + "_features.csv"
+    # check if the dataset is 2D (NZ == 1 implies a single z-layer)
     if parent.NZ == 1:
         print("GUI_INFO: saving features to CSV file")
         save_features_csv(parent.filename)

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -10,7 +10,7 @@ import tifffile
 import logging
 import fastremap
 
-from ..io import imread, imsave, outlines_to_text, add_model, remove_model, save_rois, save_settings
+from ..io import imread, imsave, outlines_to_text, add_model, remove_model, save_rois, save_settings, save_features_csv
 from ..models import normalize_default, MODEL_DIR, MODEL_LIST_PATH, get_user_models
 from ..utils import masks_to_outlines, outlines_list
 
@@ -554,6 +554,20 @@ def _masks_to_gui(parent, masks, outlines=None, colors=None):
     else:
         parent.ViewDropDown.setCurrentIndex(0)
 
+def _save_features_csv(parent):
+    """
+    Saves features to CSV if dataset is 2D.
+
+    Args:
+        parent: GUI object with filename and NZ attributes.
+    """
+    filename = parent.filename
+    base = os.path.splitext(filename)[0] + "_features.csv"
+    if parent.NZ == 1:
+        print("GUI_INFO: saving features to CSV file")
+        save_features_csv(parent.filename)
+    else:
+        print("ERROR: cannot save features")
 
 def _save_png(parent):
     """ save masks to png or tiff (if 3D) """

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -561,9 +561,11 @@ def _save_features_csv(parent):
     Args:
         parent: GUI object with filename and NZ attributes.
     """
-    
+
+    # check if a file is loaded, if not, print an error message and return
     if not parent.filename:
-        raise FileNotFoundError("ERROR: No file loaded. Please load a file before attempting to save features.")
+        print("ERROR: No file loaded. Please load a file before attempting to save features.")
+        return
 
     filename = parent.filename
     base = os.path.splitext(filename)[0] + "_features.csv"

--- a/cellpose/gui/menus.py
+++ b/cellpose/gui/menus.py
@@ -81,7 +81,7 @@ def mainmenu(parent):
     The function `_save_features_as_csv` from the `io` module is called when the user clicks on the menu item.
     """
     parent.saveFeaturesCsv = QAction("Save Features as .&csv", parent)
-    parent.saveFeaturesCsv.setShortcut("Ctrl+C")
+    parent.saveFeaturesCsv.setShortcut("Ctrl+Shift+C")
     parent.saveFeaturesCsv.triggered.connect(lambda: io._save_features_csv(parent))
     file_menu.addAction(parent.saveFeaturesCsv)
     parent.saveFeaturesCsv.setEnabled(True)

--- a/cellpose/gui/menus.py
+++ b/cellpose/gui/menus.py
@@ -75,6 +75,17 @@ def mainmenu(parent):
     file_menu.addAction(parent.saveSettings)
     parent.saveSettings.setEnabled(True)
 
+    """
+    This adds a new menu item for saving features as a .csv file. 
+    The user can activate this function to export specific data directly from the GUI.
+    The function `_save_features_as_csv` from the `io` module is called when the user clicks on the menu item.
+    """
+    parent.saveFeaturesCsv = QAction("Save Features as .&csv", parent)
+    parent.saveFeaturesCsv.setShortcut("Ctrl+S")
+    parent.saveFeaturesCsv.triggered.connect(lambda: io._save_features_csv(parent))
+    file_menu.addAction(parent.saveFeaturesCsv)
+    parent.saveFeaturesCsv.setEnabled(True)
+
 def editmenu(parent):
     main_menu = parent.menuBar()
     edit_menu = main_menu.addMenu("&Edit")

--- a/cellpose/gui/menus.py
+++ b/cellpose/gui/menus.py
@@ -81,7 +81,7 @@ def mainmenu(parent):
     The function `_save_features_as_csv` from the `io` module is called when the user clicks on the menu item.
     """
     parent.saveFeaturesCsv = QAction("Save Features as .&csv", parent)
-    parent.saveFeaturesCsv.setShortcut("Ctrl+S")
+    parent.saveFeaturesCsv.setShortcut("Ctrl+C")
     parent.saveFeaturesCsv.triggered.connect(lambda: io._save_features_csv(parent))
     file_menu.addAction(parent.saveFeaturesCsv)
     parent.saveFeaturesCsv.setEnabled(True)

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -562,7 +562,8 @@ def masks_flows_to_seg(images, masks, flows, file_names, diams=30., channels=Non
     np.save(base + "_seg.npy", dat)
 
 def save_features_csv(file_name):
-    """ save features to .csv file and remove if it already exists
+    """
+    Save features to .csv file and remove if it already exists
     Args:
         file_name (str): Target CSV file name
 

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import re
 from . import version_str
 from roifile import ImagejRoi, roiwrite
+import csv
 
 try:
     from qtpy import QtGui, QtCore, Qt, QtWidgets
@@ -559,6 +560,25 @@ def masks_flows_to_seg(images, masks, flows, file_names, diams=30., channels=Non
         dat["img_restore"] = imgs_restore
 
     np.save(base + "_seg.npy", dat)
+
+def save_features_csv(file_name):
+    """ save features to .csv file and remove if it already exists
+    Args:
+        file_name (str): Target CSV file name
+
+    Returns:
+        None
+    """
+    file_name = os.path.splitext(file_name)[0] + "_cp_features.csv"
+    if os.path.exists(file_name):
+        os.remove(file_name)
+    with open(file_name, mode='w', newline='') as csv_file:
+        fieldnames = ['Features', 'Value']
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        # rows can be added as needed
+        # writer.writerow({'Feature': 'example_feature', 'Value': 'example_value'})
+        # Add more rows as needed
 
 def save_to_png(images, masks, flows, file_names):
     """ deprecated (runs io.save_masks with png=True) 

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -572,13 +572,9 @@ def save_features_csv(file_name):
     file_name = os.path.splitext(file_name)[0] + "_cp_features.csv"
     if os.path.exists(file_name):
         os.remove(file_name)
-    with open(file_name, mode='w', newline='') as csv_file:
-        fieldnames = ['Features', 'Value']
-        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
-        writer.writeheader()
-        # rows can be added as needed
-        # writer.writerow({'Feature': 'example_feature', 'Value': 'example_value'})
-        # Add more rows as needed
+    with open(file_name, mode='w', newline='') as f:
+        # creating an empty csv file or clearing the existing one
+        pass
 
 def save_to_png(images, masks, flows, file_names):
     """ deprecated (runs io.save_masks with png=True) 


### PR DESCRIPTION
resolves #30 

## Description

Files can now be exported as CSV files in the same directory through the new "Save Features as .csv" option in the "File" dropdown menu. The files keep their name and get the suffix "_cp_features.csv" added.


## Changes

The files cellpose/gui/io.py, cellpose/gui/menus.py, cellpose/io.py were modified.

 - method `_save_features_csv(parent)` was added which calls `save_features_csv(parent.filename`) if the dataset is two-dimensional (parent.NZ == 1) to save feature data in a CSV file. Otherwise, it outputs an error message.
 -  method `save_features_csv(file_name)` was created which creates or overwrites a CSV file named filename_cp_features.csv without saving content.
 -  a ´Save Features as .csv´button` was added to the dropdown menu.
     -   `shortcut: Ctrl+C` was created for this option.

## Testing 
The function can be tested by uploading an image and then clicking Save Features as .csv in the File menu.

## Notes
Asking the user if they really want to replace the file before removing it could be implemented in another issue.