### PR TITLE
49 Import multi-layer tiff images and convert them for visualization 

### DIFF
--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -9,7 +9,7 @@ import cv2
 import tifffile
 import logging
 import fastremap
-from PIL import Image, ImageSequence
+from PIL import Image, ImageSequence, ImageOps
 
 from ..io import imread, imsave, outlines_to_text, add_model, remove_model, save_rois, save_settings
 from ..models import normalize_default, MODEL_DIR, MODEL_LIST_PATH, get_user_models
@@ -108,6 +108,9 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
     #checks if the file is a tiff
     if filename and (filename.endswith('.tif') or filename.endswith('.tiff')):
         processed_images = process_tiff_image(filename)
+        for i, img in enumerate(processed_images):
+            img.show(title=f"Processed Image {i}")
+        parent.processed_images = processed_images
     if filename is None:
         name = QFileDialog.getOpenFileName(parent, "Load image")
         filename = name[0]
@@ -443,6 +446,7 @@ def _load_masks(parent, filename=None):
     """ load zeros-based masks (0=no cell, 1=cell 1, ...) """
     if filename is None:
         name = QFileDialog.getOpenFileName(parent, "Load masks (PNG or TIFF)")
+        print()
         filename = name[0]
     print(f"GUI_INFO: loading masks: {filename}")
     masks = imread(filename)
@@ -732,20 +736,40 @@ def process_tiff_image(tiff_file):
 
 def convert_grayscale_to_opacity(frame):
     """
-    Converts a grayscale image frame to opacity format.
-    Converts the image to 16-bit grayscale, extracts the alpha channel,
-    and merges it with a white background to create an opacity-enhanced image.
+    Converts an image frame to opacity format.
+    - For 16-bit grayscale images, it extracts the alpha channel from the high byte.
+    - For RGB images, it creates an alpha channel based on the image's luminance with a simple threshold.
+    - For 8-bit grayscale images, it creates an alpha channel with a simple threshold.
 
     Parameters:
-    - frame (PIL.Image): Input grayscale image frame.
+    - frame (PIL.Image): Input image frame.
 
     Returns:
-    - final_image (PIL.Image): Processed opacity-enhanced image.
+    - final_image (PIL.Image): Processed image with an alpha channel in RGBA format.
     """
-    frame = frame.convert("I;16B")
-    image_np = np.array(frame)
-    alpha_np = (image_np >> 8).astype(np.uint8)
-    alpha = Image.fromarray(alpha_np)
-    white_bg = Image.new("L", frame.size, 255)
-    final_image = Image.merge("LA", (white_bg, alpha))
-    return final_image
+    if frame.mode == 'I;16B':
+        frame = frame.convert("I;16B")
+        image_np = np.array(frame)
+        alpha_np = (image_np >> 8).astype(np.uint8)
+        alpha = Image.fromarray(alpha_np, mode="L")
+        white_bg = Image.new("L", frame.size, 255)
+        final_image = Image.merge("LA", (white_bg, alpha))
+        rgba_image = final_image.convert("RGBA")
+        return rgba_image
+
+    elif frame.mode == 'RGB':
+        luminance = frame.convert("L")
+        alpha = luminance.point(lambda p: 255 if p < 128 else 0)
+        alpha = ImageOps.invert(alpha)
+        white_bg = Image.new("L", frame.size, 255)
+        final_image = Image.merge("LA", (white_bg, alpha))
+        rgba_image = final_image.convert("RGBA")
+        return rgba_image
+
+    else:  # 8-bit grayscale
+        alpha = frame.point(lambda p: 255 if p < 128 else 0)
+        alpha = ImageOps.invert(alpha)
+        white_bg = Image.new("L", frame.size, 255)
+        final_image = Image.merge("LA", (white_bg, alpha))
+        rgba_image = final_image.convert("RGBA")
+        return rgba_image

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -108,8 +108,6 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
     #checks if the file is a tiff
     if filename and (filename.endswith('.tif') or filename.endswith('.tiff')):
         processed_images = process_tiff_image(filename)
-        for i, img in enumerate(processed_images):
-            img.show(title=f"Processed Image {i}")
         parent.processed_images = processed_images
     if filename is None:
         name = QFileDialog.getOpenFileName(parent, "Load image")


### PR DESCRIPTION
resolves #49

Ich habe das Ticket gelöst, in dem abgefragt wird ob ein tif/tiff image geladen wird. Falls ja, gehen wir in die Funktion "process_tiff_image" welche über jedes layer iteriert und mit diesem jeweils die Funktion "convert_grayscale_to_opacity" aufruft. Dort werden die Frames dann wie gefragt konvertiert. Die Hauptfunktionalität ist in keiner Weise beeinflusst. 

Im Commit gibt es keine Debug-Anzeigen o.Ä.. Falls ihr die Funktionalität testen wollt, könnt ihr den Code verändern wie unten zu sehen ist. Dabei werden die einzelnen konvertierten Layer geöffnet und angezeigt.


In _load_image:

```
if filename and (filename.endswith('.tif') or filename.endswith('.tiff')):
        processed_images = process_tiff_image(filename)
        for i, img in enumerate(processed_images):
            img.show(title=f"Processed Image {i}")
        parent.processed_images = processed_images
```