### PR TITLE
44 curser position information on mouseclick

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1301,7 +1301,7 @@ class MainW(QMainWindow):
             io._load_image(self, filename=files[0], load_seg=True, load_3D=self.load_3D)
 
         self.minimapWindow.setChecked(True)  # Check the minimap menu item
-        self.toggle_minimap(True)
+        self.minimap_window()
 
     def toggle_masks(self):
         if self.MCheckBox.isChecked():

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -416,6 +416,7 @@ class MinimapWindow(QDialog):
         self.title = "Minimap"
         self.setWindowTitle(self.title)
         self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+        self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
 
         # Create a QGridLayout for the window
         layout = QGridLayout()

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -503,12 +503,9 @@ class MinimapWindow(QDialog):
         self.lastClickPos = (viewboxPos.x(), viewboxPos.y())
 
         # Normalize the clicked position's coordinates to values between 0 and 1.
-        normalized_x = viewboxPos.x() - 9/ self.viewbox.width()
-        normalized_y = viewboxPos.y() - 9/ self.viewbox.height()
+        normalized_x = (viewboxPos.x() - 9)/ self.viewbox.width()
+        normalized_y = (viewboxPos.y() - 9)/ self.viewbox.height()
         self.normalizedClickPos = (normalized_x, normalized_y)
-
-        # Update the position of the minimap
-        self.viewbox.autoRange()
 
 
 class ViewBoxNoRightDrag(pg.ViewBox):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -543,15 +543,15 @@ class MinimapWindow(QDialog):
 
     def mousePressEvent(self, event):
         """
-        Handle mouse press events, distinguishing between left and right button clicks.
-
         Method to handle mouse press events. This overrides the default mousePressEvent method. Various information
         about the mouse event are passed to the method and handled accordingly. The method can distinguish between
-        left and right mouse button clicks. If the right mouse button is clicked, the custom context menu is displayed.
+        left and right mouse button clicks.
 
-        The else branch handles mouse press events on the minimap.
-        This method is triggered when the user left-clicks on the minimap,
-        allowing for interaction such as navigating the main image view.
+        The first part of the method checks if the right mouse button is clicked, in which case the custom context menu
+        is displayed.
+
+        The else branch of the method checks if the user left-clicks on the minimap, in which case it enables
+        interactions such as navigating the main image view.
 
         Returns:
             Normalized (x, y) positions of the mouse click within the minimap.

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -490,6 +490,28 @@ class MinimapWindow(QDialog):
         else:
             self.setFixedSize(400, 400)
 
+    def mousePressEvent(self, event):
+        """
+        Handles mouse press events on the minimap.
+        This method is triggered when the user clicks on the minimap,
+        allowing for interaction such as navigating the main image view.
+        """
+        # Obtain the position where the mouse was clicked within the minimap.
+        pos = event.pos()
+
+        # Map the position to the coordinate system of the viewbox
+        viewboxPos = self.viewbox.mapToView(pos)
+
+        # Save the translated position for later use
+        self.lastClickPos = (viewboxPos.x(), viewboxPos.y())
+
+        # Normalize the clicked position's coordinates to values between 0 and 1.
+        normalized_x = viewboxPos.x() / self.viewbox.width()
+        normalized_y = viewboxPos.y() / self.viewbox.height()
+        self.normalizedClickPos = (normalized_x, normalized_y)
+
+        # Update the position of the minimap
+        self.viewbox.autoRange()
 
 
 class ViewBoxNoRightDrag(pg.ViewBox):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -497,17 +497,14 @@ class MinimapWindow(QDialog):
         allowing for interaction such as navigating the main image view.
         """
         # Obtain the position where the mouse was clicked within the minimap.
-        pos = event.pos()
-
-        # Map the position to the coordinate system of the viewbox
-        viewboxPos = self.viewbox.mapToView(pos)
+        viewboxPos = event.pos()
 
         # Save the translated position for later use
         self.lastClickPos = (viewboxPos.x(), viewboxPos.y())
 
         # Normalize the clicked position's coordinates to values between 0 and 1.
-        normalized_x = viewboxPos.x() / self.viewbox.width()
-        normalized_y = viewboxPos.y() / self.viewbox.height()
+        normalized_x = viewboxPos.x() - 9/ self.viewbox.width()
+        normalized_y = viewboxPos.y() - 9/ self.viewbox.height()
         self.normalizedClickPos = (normalized_x, normalized_y)
 
         # Update the position of the minimap

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -494,8 +494,11 @@ class MinimapWindow(QDialog):
     def mousePressEvent(self, event):
         """
         Handles mouse press events on the minimap.
-        This method is triggered when the user clicks on the minimap,
+        This method is triggered when the user left-clicks on the minimap,
         allowing for interaction such as navigating the main image view.
+
+        Returns:
+            Normalized (x, y) positions of the mouse click within the minimap.
         """
         # Obtain the position where the mouse was clicked within the minimap.
         viewboxPos = event.pos()


### PR DESCRIPTION
resolves #44 

## Description
When clicking on the minimap, the mousePressEvent is triggered, capturing and storing the coordinates of the clicked position. The stored coordinates are used in Ticket 45 to enable navigation in the image via the minimap.

## Changes
- overrode `mousePressEvent` in the `MinimapWindow` class
- normalized coordinates and saved the x-coordinate in `normalized_x` and the y-coordinate in `normalized_y`
- saved coordinates in `self.lastClickPos` and the normalized ones in `self.normalizedClickPos`

## Testing
To test the implementation, you can add `print(f"Minimap clicked at: {normalized_x}, {normalized_y}")` in the overridden mousePressEvent method before running Cellpose to check if clicking on the minimap triggers mousePressEvent and normalizes the coordinates.