### PR TITLE
46 navigate via the minimap minimap navigation

### DIFF
--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -554,7 +554,7 @@ class MinimapWindow(QDialog):
         normalized_y = (viewboxPos.y() - 9)/ self.viewbox.height()
         self.normalizedClickPos = (normalized_x, normalized_y)
 
-        self.parent.center_view_on_position(self, normalized_x, normalized_y)
+        self.parent().center_view_on_position(normalized_x, normalized_y)
 
 
 class ViewBoxNoRightDrag(pg.ViewBox):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -541,6 +541,25 @@ class MinimapWindow(QDialog):
 
     def mousePressEvent(self, event):
         """
+        Method to handle mouse press events. This overrides the default mousePressEvent method. Various information
+        about the mouse event are passed to the method and handled accordingly. The method can distinguish between
+        left and right mouse button clicks. If the right mouse button is clicked, the custom context menu is displayed.
+        """
+        # Check if the right mouse button was pressed
+        if event.button() == QtCore.Qt.RightButton:
+            # Show the custom context menu at the mouse position
+            self.contextMenu.exec_(event.globalPos())
+            # Delete hint after first interaction with the resize slider
+            if self.rightClickInteraction:
+                self.setWindowTitle("Minimap")
+                self.rightClickInteraction = False
+
+        else:
+            # If another mouse button was pressed, call the base class implementation
+            super().mousePressEvent(event)
+
+    def mousePressEvent(self, event):
+        """
         Handles mouse press events on the minimap.
         This method is triggered when the user clicks on the minimap,
         allowing for interaction such as navigating the main image view.

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -411,10 +411,6 @@ class MinimapWindow(QDialog):
         self.title = "Minimap (click right mouse button to resize)"
         self.setWindowTitle(self.title)
         self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
-<<<<<<< HEAD
-=======
-
->>>>>>> origin/main
         self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
 
         # Set min, max and default size of the minimap
@@ -549,14 +545,8 @@ class MinimapWindow(QDialog):
         Method to handle mouse press events. This overrides the default mousePressEvent method. Various information
         about the mouse event are passed to the method and handled accordingly. The method can distinguish between
         left and right mouse button clicks.
-<<<<<<< HEAD
         THe first part of method checks if the right mouse button is clicked, in which case the custom context menu
         is displayed.
-=======
-
-        The first part of the method checks if the right mouse button is clicked, in which case the custom context menu
-        is displayed.
-
         The else branch of the method checks if the user left-clicks on the minimap, in which case it enables
         interactions such as navigating the main image view.
 
@@ -591,7 +581,6 @@ class MinimapWindow(QDialog):
 
             # Change the view in the main window to the clicked position
             self.parent().center_view_on_position(normalized_x, normalized_y)
-
 
 
 class ViewBoxNoRightDrag(pg.ViewBox):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -539,25 +539,6 @@ class MinimapWindow(QDialog):
 
     def mousePressEvent(self, event):
         """
-        Method to handle mouse press events. This overrides the default mousePressEvent method. Various information
-        about the mouse event are passed to the method and handled accordingly. The method can distinguish between
-        left and right mouse button clicks. If the right mouse button is clicked, the custom context menu is displayed.
-        """
-        # Check if the right mouse button was pressed
-        if event.button() == QtCore.Qt.RightButton:
-            # Show the custom context menu at the mouse position
-            self.contextMenu.exec_(event.globalPos())
-            # Delete hint after first interaction with the resize slider
-            if self.rightClickInteraction:
-                self.setWindowTitle("Minimap")
-                self.rightClickInteraction = False
-
-        else:
-            # If another mouse button was pressed, call the base class implementation
-            super().mousePressEvent(event)
-
-    def mousePressEvent(self, event):
-        """
         Handles mouse press events on the minimap.
         This method is triggered when the user clicks on the minimap,
         allowing for interaction such as navigating the main image view.
@@ -572,6 +553,8 @@ class MinimapWindow(QDialog):
         normalized_x = (viewboxPos.x() - 9)/ self.viewbox.width()
         normalized_y = (viewboxPos.y() - 9)/ self.viewbox.height()
         self.normalizedClickPos = (normalized_x, normalized_y)
+
+        self.parent.center_view_on_position(self, normalized_x, normalized_y)
 
 
 class ViewBoxNoRightDrag(pg.ViewBox):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -545,8 +545,10 @@ class MinimapWindow(QDialog):
         Method to handle mouse press events. This overrides the default mousePressEvent method. Various information
         about the mouse event are passed to the method and handled accordingly. The method can distinguish between
         left and right mouse button clicks.
-        THe first part of method checks if the right mouse button is clicked, in which case the custom context menu
+
+        The first part of the method checks if the right mouse button is clicked, in which case the custom context menu
         is displayed.
+
         The else branch of the method checks if the user left-clicks on the minimap, in which case it enables
         interactions such as navigating the main image view.
 
@@ -561,11 +563,6 @@ class MinimapWindow(QDialog):
             if self.rightClickInteraction:
                 self.setWindowTitle("Minimap")
                 self.rightClickInteraction = False
-                """
-                The second part of the method handles mouse press events on the minimap.
-                This method is triggered when the user clicks on the minimap,
-                allowing for interaction such as navigating the main image view.
-             """
         else:
 
             # Obtain the position where the mouse was clicked within the minimap.

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -543,7 +543,9 @@ class MinimapWindow(QDialog):
         """
         Method to handle mouse press events. This overrides the default mousePressEvent method. Various information
         about the mouse event are passed to the method and handled accordingly. The method can distinguish between
-        left and right mouse button clicks. If the right mouse button is clicked, the custom context menu is displayed.
+        left and right mouse button clicks.
+        THe first part of method checks if the right mouse button is clicked, in which case the custom context menu
+        is displayed.
         """
         # Check if the right mouse button was pressed
         if event.button() == QtCore.Qt.RightButton:
@@ -553,30 +555,26 @@ class MinimapWindow(QDialog):
             if self.rightClickInteraction:
                 self.setWindowTitle("Minimap")
                 self.rightClickInteraction = False
-
+                """
+                The second part of the method handles mouse press events on the minimap.
+                This method is triggered when the user clicks on the minimap,
+                allowing for interaction such as navigating the main image view.
+             """
         else:
-            # If another mouse button was pressed, call the base class implementation
-            super().mousePressEvent(event)
 
-    def mousePressEvent(self, event):
-        """
-        Handles mouse press events on the minimap.
-        This method is triggered when the user clicks on the minimap,
-        allowing for interaction such as navigating the main image view.
-        """
-        # Obtain the position where the mouse was clicked within the minimap.
-        viewboxPos = event.pos()
+            # Obtain the position where the mouse was clicked within the minimap.
+            viewboxPos = event.pos()
 
-        # Save the translated position for later use
-        self.lastClickPos = (viewboxPos.x(), viewboxPos.y())
+            # Save the translated position for later use
+            self.lastClickPos = (viewboxPos.x(), viewboxPos.y())
 
-        # Normalize the clicked position's coordinates to values between 0 and 1.
-        normalized_x = (viewboxPos.x() - 9)/ self.viewbox.width()
-        normalized_y = (viewboxPos.y() - 9)/ self.viewbox.height()
-        self.normalizedClickPos = (normalized_x, normalized_y)
+            # Normalize the clicked position's coordinates to values between 0 and 1.
+            normalized_x = (viewboxPos.x() - 9)/ self.viewbox.width()
+            normalized_y = (viewboxPos.y() - 9)/ self.viewbox.height()
+            self.normalizedClickPos = (normalized_x, normalized_y)
 
-        # Change the view in the main window to the clicked position
-        self.parent().center_view_on_position(normalized_x, normalized_y)
+            # Change the view in the main window to the clicked position
+            self.parent().center_view_on_position(normalized_x, normalized_y)
 
 
 class ViewBoxNoRightDrag(pg.ViewBox):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -554,6 +554,7 @@ class MinimapWindow(QDialog):
         normalized_y = (viewboxPos.y() - 9)/ self.viewbox.height()
         self.normalizedClickPos = (normalized_x, normalized_y)
 
+        # Change the view in the main window to the clicked position
         self.parent().center_view_on_position(normalized_x, normalized_y)
 
 

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -411,6 +411,8 @@ class MinimapWindow(QDialog):
         self.title = "Minimap (click right mouse button to resize)"
         self.setWindowTitle(self.title)
         self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+        self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
+
         # Set min, max and default size of the minimap
         self.defaultSize = 400
         self.minimumSize = 100

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -562,7 +562,6 @@ class MinimapWindow(QDialog):
 
         Returns:
             Normalized (x, y) positions of the mouse click within the minimap.
->>>>>>> origin/main
         """
         # Check if the right mouse button was pressed
         if event.button() == QtCore.Qt.RightButton:


### PR DESCRIPTION
solves #46 

### Description

When clicking on any position of the minimap, the view area of the main window shifts, so that the position of the click becomes the new center view. The level of zoom remains the same. This combines the functionalities of tickets #44 and #45 and allows to navigate to different parts of the image quickly.

### Changes

Called center_view_on_position() method of the MainW class within the mousePressEvent() method of the MinimapWindow class. 

### Testing

One can test by opening the minimap with an image and clicking on different parts of it with different zoom levels in the main window.


