### PR TITLE
accessing the desired state of masks and input #31

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1558,6 +1558,7 @@ class MainW(QMainWindow):
             io._save_sets_with_check(self)
 
         self.update_layer()
+        self.print_cellpix()
 
     def remove_single_cell(self, idx):
         # remove from manual array

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -323,6 +323,26 @@ class MainW(QMainWindow):
         self.win.show()
         self.show()
 
+    def print_cellpix(self):
+        """
+        Prints the contents of the cellpix attribute.
+        """
+        # Save the current print options
+        # original_options = np.get_printoptions()
+
+        # Set the print options to display the entire array
+        # np.set_printoptions(threshold=np.inf)
+
+        # Print the cellpix array
+        print(self.cellpix)
+
+        # print unique values in cellpix array
+        unique_values = np.unique(self.cellpix)
+        print("Unique values in cellpix:", unique_values)
+
+        # Reset the print options to their original values
+        # np.set_printoptions(**original_options)
+
     def help_window(self):
         HW = guiparts.HelpWindow(self)
         HW.show()
@@ -1943,6 +1963,7 @@ class MainW(QMainWindow):
         d = datetime.datetime.now()
         self.track_changes.append(
             [d.strftime("%m/%d/%Y, %H:%M:%S"), "added mask", [ar, ac]])
+        self.print_cellpix()
         return median
 
     def draw_mask(self, z, ar, ac, vr, vc, color, idx=None):

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -570,6 +570,8 @@ def _masks_to_gui(parent, masks, outlines=None, colors=None):
     else:
         parent.ViewDropDown.setCurrentIndex(0)
 
+    parent.print_cellpix()
+
 def _save_features_csv(parent):
     """
     Saves features to CSV if dataset is 2D.


### PR DESCRIPTION
solves #31  

### Description
Here, I indicate where the most recent state of the masks is stored (1) and how to access the original state of a loaded image (2), so that this information is available to developers while implementing ticket #32 . I provide some context and explain how to test that the variables have the desired information.

(Note: This PR is created to facilitate reviewing, testing and grading. The branch is not intended to be merged with main, given the nature of the research task.)

### 1. Location of final masks results
**Short answer**: cellpix attribute of the MainW class.

**Context**: There are many different variables and methods involved in storing and processing mask information. Given that the the state of the masks can change if a user manually deletes, merges or draws extra cells, it is important to find the storage place of the most recent versions of the segmentation. I found that the cellpix attribute of the MainW class serves this purpose: it is reinitialized to an array of zeros in reset() and in clear_all(); it is updated in remove_cell() and draw_masks(); it is accessed in select_cell() to pinpoint a single cell, just to name a few cases. One can search for the variable's name in the gui.py file to see that virtually all methods that contribute to the segmentation either access or alter _cellpix_.

Although the _masks_to_gui() method of MainW contains the the variable masks, which also holds mask info, is mainly used by other functions to load changes into the GUI; it does not guarantee to hold the most recent version at all times. Cellpix, as a class attribute, is also more accessible, given that we can retrieve it's contents wherever we have access to the instance of our mainW class. For this reason, the appropriate place to look for the most recent state of the masks is the self.cellpix attribute of the MainW class.

**Test**: To test this, please go to branch "31-accessing-the-desired-state-of-masks-and-input", where the the method print_cellpix was created in the MainW class in gui.py. The purpose of the method is to display the contents of self.cellpix both after an initial segmentation as well as after manually adding or deleting single cells, so as to show that cellpix keeps track of the current amount of cells. To this end, print_cellpix is called at the end of _masks_to_gui (used in the intial segmentation), at the end of add_mask() (used when one draws an extra cell) and at the end of remove_cell(). If one runs the segmentation and then uses a right mouse click to draw an additional cell, the messages on the terminal allow one to see that cellpix indeed keeps inmedate track of the recent changes.

**Example screenshots**: 
Upon running a segmentation, the terminal should look like this:

<img width="1006" alt="First message after seg" src="https://github.com/user-attachments/assets/6dea437f-bb45-4731-8464-286c448c167c">
The comment "Unique values in cellpix: ..." is printed by the print_cellpix method and shows the unique values in the array / number of cells (104). 



After adding two cells (106):
<img width="1041" alt="Adding two cells" src="https://github.com/user-attachments/assets/40f02fdf-7d87-47ae-b0ba-204617954bb5">


And after removing two cells (102):
<img width="1086" alt=" removing two cells" src="https://github.com/user-attachments/assets/e7249b45-83a8-4807-8802-13dd70ba4559">


All the comments that start with "GUI_INFO: ... " were there before and are not added by me. Even though they also show accurate info about the cells, this info often stems from different sources, whereas print_cellpix() always references _cellpix_. For example, when a statement like "GUI_INFO: 102 ROIs saved to .../Desktop/6843_512r_seg.npy" is printed, the amount of cells/ROIs (=105) is retrieved from the **ncells** attribute of the mainW class (see last line of _save_sets() methods in io.py); however, a message like "GUI_INFO: 106 masks found" stems from the line `print(f"GUI_INFO: {masks.max()} masks found")` in _masks_to_gui(), which takes the amount of cells from the **masks** variable and not from ncells. So this kind of statements are not very useful to us in this ticket. 

Also, print_cellpix() has some commented out lines that, if commented in, can show the entire array if required. The commented out version shows a short version of the array that can be ignored.

### 2. Location of the unaltered image array (closed)

In previous versions, there was no variable or attribute in the code responsible for keeping an intact version of the original image. For instance, the self.img.image attribute stored the image array but was subject to modifications. #34 solved this problem, now the original version of an uploaded image is stored in the self.grayscale_image_stack attribute.