### PR TITLE
40 Position and Size Information of the Drawing Area Contents

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -301,7 +301,7 @@ class MainW(QMainWindow):
         self.reset()
         self.minimap_window_instance = None
 
-        # if the image in the viewbox is zoomed in/out, the method onViewChanged is called
+        # if the image in the view box is changed, the method onViewChanged is called
         self.p0.sigRangeChanged.connect(self.onViewChanged)
 
         # if called with image, load it
@@ -409,22 +409,27 @@ class MainW(QMainWindow):
 
     def onViewChanged(self):
         """
-        This function is called when the view in the viewbox is changed.
-        This happens, whenever the image is zoomed in or zoomed out.
-        It saves the coordinates of the viewbox, as well as its width and height.
+        This function is called when the view in the view box is changed.
+        This happens, whenever the view of the image is changed in some way.
+        This includes it being zoomed in or zoomed out, as well as it being moved around.
+
+        Returns:
+            Coordinates of the view box (x, y)
+            Dimensions of the view box (width, height)
         """
-        # Access the positional values of the viewbox p0 in form of a rectangle using viewRect()
+        # Access the positional values of the view box p0 in form of a rectangle using viewRect()
         view_rect = self.p0.viewRect()
 
-        # Extract the x and y coordinates of the viewbox
+        # Extract the x and y coordinates of the view box
         x = view_rect.left()
         y = view_rect.top()
+        # (alternatively, you could use view_rect.x() and view_rect.y(), it results in the same coordinates)
 
-        # Extract the dimensions of the viewbox
+        # Extract the dimensions of the view box
         width = view_rect.width()
         height = view_rect.height()
 
-        # Print the coordinates and dimensions of the viewbox for control purposes
+        # Print the coordinates and dimensions of the view box for control purposes
         print(f"Viewbox coordinates: x={x}, y={y}")
         print(f"Viewbox dimensions: width={width}, height={height}")
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -301,7 +301,7 @@ class MainW(QMainWindow):
         self.reset()
         self.minimap_window_instance = None
 
-        # if the image in the view box is changed, the method onViewChanged is called
+        # if the view of the image is changed, the method onViewChanged is called
         self.p0.sigRangeChanged.connect(self.onViewChanged)
 
         # if called with image, load it
@@ -409,9 +409,9 @@ class MainW(QMainWindow):
 
     def onViewChanged(self):
         """
-        This function is called when the view in the view box is changed.
-        This happens whenever the view of the image is changed in some way.
+        This function is called whenever the view of the image in the view box is changed.
         This includes it being zoomed in or zoomed out, as well as it being moved around.
+        It normalizes coordinates and dimensions of the view box in relation to the current image.
 
         Returns:
             Normalized coordinates of the view box (normalized_x, normalized_y)
@@ -422,7 +422,6 @@ class MainW(QMainWindow):
         img_height = self.img.image.shape[0]
         img_width = self.img.image.shape[1]
 
-        # version using viewRect
         # Access the positional values of the view box p0 in form of a rectangle using viewRect()
         view_rect = self.p0.viewRect()
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -418,10 +418,6 @@ class MainW(QMainWindow):
             Normalized dimensions of the view box (normalized_width, normalized_height)
         """
 
-        # Get the size of the image
-        img_height = self.img.image.shape[0]
-        img_width = self.img.image.shape[1]
-
         # Access the positional values of the view box p0 in form of a rectangle using viewRect()
         view_rect = self.p0.viewRect()
 
@@ -433,16 +429,31 @@ class MainW(QMainWindow):
         width = view_rect.width()
         height = view_rect.height()
 
-        # Calculate the normalized coordinates in relation to the image size
-        normalized_x = tuple(
-            coordinate / img_width for coordinate in x_coordinates)
-        normalized_y = tuple(
-            coordinate / img_height for coordinate in y_coordinates)
+        # Print statements to test the absolute values of coordinates and dimensions
+        print(f"Viewbox coordinates: x={x_coordinates}, y={y_coordinates}")
+        print(f"Viewbox dimensions: width={width}, height={height}")
 
-        # Calculate the normalized dimensions
-        normalized_width = width / img_width
-        normalized_height = height / img_height
+        if self.img.image is not None:
 
+            # Get the size of the image
+            img_height = self.img.image.shape[0]
+            img_width = self.img.image.shape[1]
+
+            # Calculate the normalized coordinates in relation to the image size
+            normalized_x = tuple(
+                coordinate / img_width for coordinate in x_coordinates)
+            normalized_y = tuple(
+                coordinate / img_height for coordinate in y_coordinates)
+
+            # Calculate the normalized dimensions
+            normalized_width = width / img_width
+            normalized_height = height / img_height
+
+            # Print statements to test the normalized values of coordinates and dimensions
+            print(f"Normalized Viewbox coordinates: x={normalized_x}, y={normalized_y}")
+            print(f"Normalized Viewbox dimensions: width={normalized_width}, height={normalized_height}")
+
+            return normalized_x, normalized_y, normalized_width, normalized_height
 
     def make_buttons(self):
         self.boldfont = QtGui.QFont("Arial", 11, QtGui.QFont.Bold)

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -301,6 +301,9 @@ class MainW(QMainWindow):
         self.reset()
         self.minimap_window_instance = None
 
+        # if the image in the viewbox is zoomed in/out, the method onViewChanged is called
+        self.p0.sigRangeChanged.connect(self.onViewChanged)
+
         # if called with image, load it
         if image is not None:
             self.filename = image

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -461,7 +461,7 @@ class MainW(QMainWindow):
         width = view_rect.width()
         height = view_rect.height()
 
-        if self.img.image is not None:
+        try:
 
             # Get the size of the image
             img_height = self.img.image.shape[0]
@@ -478,6 +478,11 @@ class MainW(QMainWindow):
             normalized_height = height / img_height
 
             return normalized_x, normalized_y, normalized_width, normalized_height
+
+        except Exception as e:
+
+            # if an exception of any kind occurs, the specific exception is printed to the console
+            print(f"An error occurred while changing the view: {e}")
 
     def make_buttons(self):
         self.boldfont = QtGui.QFont("Arial", 11, QtGui.QFont.Bold)

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -433,6 +433,22 @@ class MainW(QMainWindow):
         print(f"Viewbox coordinates: x={x}, y={y}")
         print(f"Viewbox dimensions: width={width}, height={height}")
 
+        # Get the size of the image
+        img_height = self.img.image.shape[0]
+        img_width = self.img.image.shape[1]
+
+        # Calulate the normalized coordinates
+        normalized_x = x / img_width
+        normalized_y = y / img_height
+
+        # Calculate the normalized dimensions
+        normalized_width = width / img_width
+        normalized_height = height / img_height
+
+        # Print the coordinates and dimensions of the view box for control purposes
+        print(f"Normalized Viewbox coordinates: x={normalized_x}, y={normalized_y}")
+        print(f"Normalized Viewbox dimensions: width={normalized_width}, height={normalized_height}")
+
 
     def make_buttons(self):
         self.boldfont = QtGui.QFont("Arial", 11, QtGui.QFont.Bold)
@@ -489,7 +505,7 @@ class MainW(QMainWindow):
         self.autobtn.setChecked(True)
         self.satBoxG.addWidget(self.autobtn, b0, 1, 1, 8)
 
-    
+
         c = 0  # position of the elements in the right side menu
 
         self.sliders = []

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -408,13 +408,23 @@ class MainW(QMainWindow):
         self.p0.setYRange(*new_y_range, padding=0)
 
     def onViewChanged(self):
-
+        """
+        This function is called when the view in the viewbox is changed.
+        This happens, whenever the image is zoomed in or zoomed out.
+        It saves the coordinates of the viewbox, as well as its width and height.
+        """
+        # Access the positional values of the viewbox p0 in form of a rectangle using viewRect()
         view_rect = self.p0.viewRect()
+
+        # Extract the x and y coordinates of the viewbox
         x = view_rect.left()
         y = view_rect.top()
+
+        # Extract the dimensions of the viewbox
         width = view_rect.width()
         height = view_rect.height()
 
+        # Print the coordinates and dimensions of the viewbox for control purposes
         print(f"Viewbox coordinates: x={x}, y={y}")
         print(f"Viewbox dimensions: width={width}, height={height}")
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -404,6 +404,17 @@ class MainW(QMainWindow):
         self.p0.setXRange(*new_x_range, padding=0)
         self.p0.setYRange(*new_y_range, padding=0)
 
+    def onViewChanged(self):
+
+        view_rect = self.p0.viewRect()
+        x = view_rect.left()
+        y = view_rect.top()
+        width = view_rect.width()
+        height = view_rect.height()
+
+        print(f"Viewbox coordinates: x={x}, y={y}")
+        print(f"Viewbox dimensions: width={width}, height={height}")
+
 
     def make_buttons(self):
         self.boldfont = QtGui.QFont("Arial", 11, QtGui.QFont.Bold)

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -429,10 +429,6 @@ class MainW(QMainWindow):
         width = view_rect.width()
         height = view_rect.height()
 
-        # Print statements to test the absolute values of coordinates and dimensions
-        print(f"Viewbox coordinates: x={x_coordinates}, y={y_coordinates}")
-        print(f"Viewbox dimensions: width={width}, height={height}")
-
         if self.img.image is not None:
 
             # Get the size of the image
@@ -448,10 +444,6 @@ class MainW(QMainWindow):
             # Calculate the normalized dimensions
             normalized_width = width / img_width
             normalized_height = height / img_height
-
-            # Print statements to test the normalized values of coordinates and dimensions
-            print(f"Normalized Viewbox coordinates: x={normalized_x}, y={normalized_y}")
-            print(f"Normalized Viewbox dimensions: width={normalized_width}, height={normalized_height}")
 
             return normalized_x, normalized_y, normalized_width, normalized_height
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -414,40 +414,96 @@ class MainW(QMainWindow):
         This includes it being zoomed in or zoomed out, as well as it being moved around.
 
         Returns:
-            Coordinates of the view box (x, y)
+            Coordinates of the view box (x_coordinates, y_coordinates)
+            Normalized coordinates of the view box (normalized_x, normalized_y)
             Dimensions of the view box (width, height)
+            Normalized dimensions of the view box (normalized_width, normalized_height)
         """
+
+        # Get the size of the image
+        img_height = self.img.image.shape[0]
+        img_width = self.img.image.shape[1]
+
+
+        """Version using viewRect"""
+
+        # version using viewRect
         # Access the positional values of the view box p0 in form of a rectangle using viewRect()
         view_rect = self.p0.viewRect()
 
         # Extract the x and y coordinates of the view box
-        x = view_rect.left()
-        y = view_rect.top()
-        # (alternatively, you could use view_rect.x() and view_rect.y(), it results in the same coordinates)
+        x_left = view_rect.left()
+        x_right = view_rect.right()
+        x_coordinates = [x_left, x_right]
+        y_top = view_rect.top()
+        y_bottom = view_rect.bottom()
+        y_coordinates = [y_top, y_bottom]
 
         # Extract the dimensions of the view box
         width = view_rect.width()
         height = view_rect.height()
 
         # Print the coordinates and dimensions of the view box for control purposes
-        print(f"Viewbox coordinates: x={x}, y={y}")
+        print(f"Viewbox coordinates: x={x_left, x_right}, y={y_top, y_bottom}")
         print(f"Viewbox dimensions: width={width}, height={height}")
 
-        # Get the size of the image
-        img_height = self.img.image.shape[0]
-        img_width = self.img.image.shape[1]
-
-        # Calulate the normalized coordinates
-        normalized_x = x / img_width
-        normalized_y = y / img_height
+        # Calculate the normalized coordinates
+        normalized_x = tuple(coordinate / img_width for coordinate in x_coordinates)
+        normalized_y = tuple(coordinate / img_height for coordinate in y_coordinates)
 
         # Calculate the normalized dimensions
         normalized_width = width / img_width
         normalized_height = height / img_height
 
         # Print the coordinates and dimensions of the view box for control purposes
-        print(f"Normalized Viewbox coordinates: x={normalized_x}, y={normalized_y}")
-        print(f"Normalized Viewbox dimensions: width={normalized_width}, height={normalized_height}")
+        print(
+            f"Normalized Viewbox coordinates: x={normalized_x}, y={normalized_y}"
+        )
+        print(
+            f"Normalized Viewbox dimensions: width={normalized_width}, height={normalized_height}"
+        )
+
+
+        """Version using viewRange (similar to centerViewOnPosition)"""
+
+        # Get the current view range of the view box p0.
+        # This tells us in form of coordinates which part of the image is currently displayed.
+        view_range = self.p0.viewRange()
+
+        # Print the coordinates for control purposes
+        print("View range: ", view_range)
+
+        # Extract the x and y ranges
+        x_range = view_range[0]
+        y_range = view_range[1]
+
+        # Calculate the normalized coordinates
+        normalized_x_range = [x_range[0] / img_width, x_range[1] / img_width]
+        normalized_y_range = [y_range[0] / img_height, y_range[1] / img_height]
+
+        # Print the normalized coordinates for control purposes
+        print("normalized x range:", normalized_x_range)
+        print("normalized y range: ", normalized_y_range)
+
+        # Calculate the current zoom level
+        zoom_x = (x_range[1] - x_range[0]) / img_width
+        zoom_y = (y_range[1] - y_range[0]) / img_height
+
+        # Calculate the width and height of the view range (= the dimensions) based on the zoom level
+        view_width = img_width * zoom_x
+        view_height = img_height * zoom_y
+
+        # Print the dimensions for control purposes
+        print("View width: ", view_width)
+        print("View height: ", view_height)
+
+        # Normalize the view width and height
+        normalized_view_width = view_width / img_width
+        normalized_view_height = view_height / img_height
+
+        # Print the normalized dimensions for control purposes
+        print("Normalized view width: ", normalized_view_width)
+        print("Normalized view height: ", normalized_view_height)
 
 
     def make_buttons(self):

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -410,13 +410,11 @@ class MainW(QMainWindow):
     def onViewChanged(self):
         """
         This function is called when the view in the view box is changed.
-        This happens, whenever the view of the image is changed in some way.
+        This happens whenever the view of the image is changed in some way.
         This includes it being zoomed in or zoomed out, as well as it being moved around.
 
         Returns:
-            Coordinates of the view box (x_coordinates, y_coordinates)
             Normalized coordinates of the view box (normalized_x, normalized_y)
-            Dimensions of the view box (width, height)
             Normalized dimensions of the view box (normalized_width, normalized_height)
         """
 
@@ -424,86 +422,27 @@ class MainW(QMainWindow):
         img_height = self.img.image.shape[0]
         img_width = self.img.image.shape[1]
 
-
-        """Version using viewRect"""
-
         # version using viewRect
         # Access the positional values of the view box p0 in form of a rectangle using viewRect()
         view_rect = self.p0.viewRect()
 
         # Extract the x and y coordinates of the view box
-        x_left = view_rect.left()
-        x_right = view_rect.right()
-        x_coordinates = [x_left, x_right]
-        y_top = view_rect.top()
-        y_bottom = view_rect.bottom()
-        y_coordinates = [y_top, y_bottom]
+        x_coordinates = [view_rect.left(), view_rect.right()]
+        y_coordinates = [view_rect.top(), view_rect.bottom()]
 
         # Extract the dimensions of the view box
         width = view_rect.width()
         height = view_rect.height()
 
-        # Print the coordinates and dimensions of the view box for control purposes
-        print(f"Viewbox coordinates: x={x_left, x_right}, y={y_top, y_bottom}")
-        print(f"Viewbox dimensions: width={width}, height={height}")
-
-        # Calculate the normalized coordinates
-        normalized_x = tuple(coordinate / img_width for coordinate in x_coordinates)
-        normalized_y = tuple(coordinate / img_height for coordinate in y_coordinates)
+        # Calculate the normalized coordinates in relation to the image size
+        normalized_x = tuple(
+            coordinate / img_width for coordinate in x_coordinates)
+        normalized_y = tuple(
+            coordinate / img_height for coordinate in y_coordinates)
 
         # Calculate the normalized dimensions
         normalized_width = width / img_width
         normalized_height = height / img_height
-
-        # Print the coordinates and dimensions of the view box for control purposes
-        print(
-            f"Normalized Viewbox coordinates: x={normalized_x}, y={normalized_y}"
-        )
-        print(
-            f"Normalized Viewbox dimensions: width={normalized_width}, height={normalized_height}"
-        )
-
-
-        """Version using viewRange (similar to centerViewOnPosition)"""
-
-        # Get the current view range of the view box p0.
-        # This tells us in form of coordinates which part of the image is currently displayed.
-        view_range = self.p0.viewRange()
-
-        # Print the coordinates for control purposes
-        print("View range: ", view_range)
-
-        # Extract the x and y ranges
-        x_range = view_range[0]
-        y_range = view_range[1]
-
-        # Calculate the normalized coordinates
-        normalized_x_range = [x_range[0] / img_width, x_range[1] / img_width]
-        normalized_y_range = [y_range[0] / img_height, y_range[1] / img_height]
-
-        # Print the normalized coordinates for control purposes
-        print("normalized x range:", normalized_x_range)
-        print("normalized y range: ", normalized_y_range)
-
-        # Calculate the current zoom level
-        zoom_x = (x_range[1] - x_range[0]) / img_width
-        zoom_y = (y_range[1] - y_range[0]) / img_height
-
-        # Calculate the width and height of the view range (= the dimensions) based on the zoom level
-        view_width = img_width * zoom_x
-        view_height = img_height * zoom_y
-
-        # Print the dimensions for control purposes
-        print("View width: ", view_width)
-        print("View height: ", view_height)
-
-        # Normalize the view width and height
-        normalized_view_width = view_width / img_width
-        normalized_view_height = view_height / img_height
-
-        # Print the normalized dimensions for control purposes
-        print("Normalized view width: ", normalized_view_width)
-        print("Normalized view height: ", normalized_view_height)
 
 
     def make_buttons(self):


### PR DESCRIPTION
resolves #40 

## The coordinates and dimensions of the view box are returned in a normalized fashion

The following changes were implemented in the class **MainW** in **cellpose/gui/gui.py**:

- when a change in the view of the image occurs (zooming or panning), a new method is triggered:
- this new method `onViewChanged` was implemented
- information of the view box p0 are extracted using `self.p0.viewRect()`:
   - x and y coordinates are extracted in form of tuples representing intervals using `.left()` and `.right()` for x / `.up()` and `.bottom()` for y 
   - width and height are extracted using `.width()` and `.height()`
- if an image is opened, size information of the current image is extracted using `self.img.image` (width and height)
- the information above is normalized:
   - the tuples representing coordinates are divided by the image width for x / image height for y
   - the view box dimensions are divided by the corresponding image dimension

This ticket is part of the former issue 12. The values `normalized_x`, `normalized_y`, `normalized_width`, `normalized_height` can later be used in ticket 42 (in combination with ticket 41).
`normalized_x` refers to the left and right border of the view box in relation to the image; `normalized_y` to the upper and lower border. Therefore, these show if the image has been moved around. The individual values in the tuples can be accessed using [0] or [1].
`normalized_width` and `normalized_height` indicate the zoom level. The bigger these values, the more zoomed-out the pictures is.

### Information for testing

I recommend using print-statements to check the values returned.
This could look for example like this: 
- for the regular coordinates and dimensions:
```
print(f"Viewbox coordinates: x={x_coordinates}, y={y_coordinates}")
print(f"Viewbox dimensions: width={width}, height={height}")
```
- for the normalized coordinates and dimensions:
```
print(f"Normalized Viewbox coordinates: x={normalized_x}, y={normalized_y}")
print(f"Normalized Viewbox dimensions: width={normalized_width}, height={normalized_height}")
```
These statements are also included in the commit 8c2b80e8257a56ee264e86a7823f892ee7cb642d.

### Showcase

Using the suggested print statements from above for testing, this should lead to a similar output in your console:
- if the image is slightly smaller than the view box and (more or less) centered:
![image](https://github.com/user-attachments/assets/8907c000-4f7d-499a-a520-d86873ba1160)
- if the image is moved like this:
![image](https://github.com/user-attachments/assets/6f08bf15-dc0d-4af1-a0a8-c849a7bebe5c)
- if the image is zoomed in:
![image](https://github.com/user-attachments/assets/d8a18d2b-8a22-4aa5-8b6d-5a3a86813c6d)

The dimensions should only change, when you zoom in or out (or if you change the window size).

If you move the left upper corner of the image into the left upper corner of the view box, the first values of the normalized intervals should be close to 0 for both x and y.  
Similarly, if you move the bottom right corner to the bottom right corner, the second values should be close to 1.
