### PR TITLE
41 display highlight area on the minimap

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -4,7 +4,6 @@ Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer a
 
 import sys, os, pathlib, warnings, datetime, time, copy
 
-from PIL import Image
 from qtpy import QtGui, QtCore
 from superqt import QRangeSlider, QCollapsible
 from qtpy.QtWidgets import QScrollArea, QMainWindow, QApplication, QWidget, QScrollBar, QComboBox, QGridLayout, QPushButton, QFrame, QCheckBox, QLabel, QProgressBar, QLineEdit, QMessageBox, QGroupBox, QColorDialog

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -451,8 +451,10 @@ class MinimapWindow(QDialog):
         # This marks the menu button as checked
         parent.minimapWindow.setChecked(True)
 
-        # Update the creation of the highlight area in the MinimapWindow class
+        # Create and add a highlight rectangle to the minimap with initial position [0, 0] and size [100, 100], outlined
+        # in white with a 3-pixel width.
         self.highlight_area = pg.RectROI([0, 0], [100, 100], pen=pg.mkPen('w', width=3))
+        # Add the highlight area to the viewbox
         self.viewbox.addItem(self.highlight_area)
 
     def closeEvent(self, event: QEvent):
@@ -537,11 +539,15 @@ class MinimapWindow(QDialog):
             if y + height > img_height:
                 height = img_height - y
 
-            # Set the position of the highlight area on the minimap
+            # Set the position of the rectangle  area on the minimap
+            # Move the rectangle to the calculated position
             self.highlight_area.setPos(x, y)
-            # Set the size of the highlight area on the minimap
+
+            # Set the size of the rectangle on the minimap
+            # Adjust the rectangle's size to the calculated width and height
             self.highlight_area.setSize([width, height])
 
+            # Return the calculated coordinates and dimensions of the rectangle
             return x, y, width, height
 
 

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -508,18 +508,41 @@ class MinimapWindow(QDialog):
     def set_highlight_area(self, normalized_x, normalized_y, normalized_width, normalized_height):
         """
         Method to set the highlight area on the minimap.
+        The position and size of the rectangle are set based on the calculated normalized coordinates from the on_view method.
+
+        Parameters:
+        normalized_x (float): Normalized x-coordinate for the position.
+        normalized_y (float): Normalized y-coordinate for the position.
+        normalized_width (float): Normalized width for the size.
+        normalized_height (float): Normalized height for the size.
+
+        Returns:
+        tuple: The calculated (x, y, width, height) coordinates.
         """
+
         if self.parent().img.image is not None:
+            # Retrieve the height and width of the image
             img_height = self.parent().img.image.shape[0]
             img_width = self.parent().img.image.shape[1]
 
+            # Calculate the position and size of the highlight area based on the normalized coordinates
             x = normalized_x * img_width
             y = normalized_y * img_height
             width = normalized_width * img_width
             height = normalized_height * img_height
 
+            # Ensure the highlight area does not exceed the boundaries of the minimap
+            if x + width > img_width:
+                width = img_width - x
+            if y + height > img_height:
+                height = img_height - y
+
+            # Set the position of the highlight area on the minimap
             self.highlight_area.setPos(x, y)
+            # Set the size of the highlight area on the minimap
             self.highlight_area.setSize([width, height])
+
+            return x, y, width, height
 
 
     def sliderValueChanged(self, value):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -538,12 +538,8 @@ class MinimapWindow(QDialog):
             height = normalized_height * img_height
 
             # Ensure the highlight area does not exceed the boundaries of the minimap
-            if x + width > img_width:
-                print("Error: Highlight area width exceeds image width.")
-                width = img_width - x
-            if y + height > img_height:
-                print("Error: Highlight area height exceeds image height.")
-                height = img_height - y
+            x = max(0, min(x, self.viewbox.width() - width))
+            y = max(0, min(y, self.viewbox.height() - height))
 
             # Set the position of the rectangle  area on the minimap
             # Move the rectangle to the calculated position

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -453,7 +453,10 @@ class MinimapWindow(QDialog):
 
         # Create and add a highlight rectangle to the minimap with initial position [0, 0] and size [100, 100], outlined
         # in white with a 3-pixel width.
-        self.highlight_area = pg.RectROI([0, 0], [100, 100], pen=pg.mkPen('w', width=3))
+        self.highlight_area = pg.RectROI([0, 0], [100, 100], pen=pg.mkPen('w', width=3), resizable=False)
+        # Remove all resize handles after initialization
+        QtCore.QTimer.singleShot(0, lambda: [self.highlight_area.removeHandle(handle) for handle in
+                                             self.highlight_area.getHandles()])
         # Add the highlight area to the viewbox
         self.viewbox.addItem(self.highlight_area)
 

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -542,10 +542,6 @@ class MinimapWindow(QDialog):
             width = normalized_width * img_width
             height = normalized_height * img_height
 
-            # Ensure the highlight area does not exceed the boundaries of the minimap
-            x = max(0, x)
-            y = max(0, y)
-
             # Set the position of the rectangle  area on the minimap
             # Move the rectangle to the calculated position
             self.highlight_area.setPos(x, y)

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -453,7 +453,8 @@ class MinimapWindow(QDialog):
 
         # Create and add a highlight rectangle to the minimap with initial position [0, 0] and size [100, 100], outlined
         # in white with a 3-pixel width.
-        self.highlight_area = pg.RectROI([0, 0], [100, 100], pen=pg.mkPen('w', width=3), resizable=False)
+        self.highlight_area = pg.RectROI([0, 0], [100, 100], pen=pg.mkPen('w', width=3), resizable=False, movable=False)
+        self.highlight_area.hoverEvent = lambda event: None
         # Remove all resize handles after initialization
         QtCore.QTimer.singleShot(0, lambda: [self.highlight_area.removeHandle(handle) for handle in
                                              self.highlight_area.getHandles()])
@@ -635,6 +636,7 @@ class MinimapWindow(QDialog):
 
             # Change the view in the main window to the clicked position
             self.parent().center_view_on_position(normalized_x, normalized_y)
+
 
 class ViewBoxNoRightDrag(pg.ViewBox):
 

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -448,6 +448,11 @@ class MinimapWindow(QDialog):
         # Add the viewbox to the image widget
         self.image_widget.addItem(self.viewbox)
 
+        # Create an instance of the HighlightArea class
+        self.highlight_area = HighlightArea(self.viewbox)
+        # Add the highlight area to the viewbox
+        self.viewbox.addItem(self.highlight_area)
+
         # This marks the menu button as checked
         parent.minimapWindow.setChecked(True)
 
@@ -578,6 +583,120 @@ class MinimapWindow(QDialog):
 
             # Change the view in the main window to the clicked position
             self.parent().center_view_on_position(normalized_x, normalized_y)
+
+class HighlightArea(pg.GraphicsObject):
+    """
+    Initialize the HighlightArea object.
+
+    Parameters:
+    parent (QGraphicsItem): The parent item of this highlight area.
+                            This is typically the ViewBox that contains the minimap. If no parent is provided, the
+                            highlight area will not be associated with any specific parent item.
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        # Set the default position and size of the highlight area (rectangle)
+        self.rect = QtCore.QRectF(50, 50, 100, 100)
+        # Make the highlight area movable by the user
+        self.setFlag(self.ItemIsMovable, True)
+        # Allow the highlight area to be selectable
+        self.setFlag(self.ItemIsSelectable, True)
+        # Ensure geometry changes (like moving or resizing) are sent to the parent item
+        self.setFlag(self.ItemSendsGeometryChanges, True)
+        # Disable hover events for this item
+        self.setAcceptHoverEvents(False)
+        # Ensure the highlight area is rendered on top of other items
+        self.setZValue(10)
+        # Initialize resizing attribute to False
+        self.resizing = False
+
+    def boundingRect(self):
+        # Return the bounding rectangle of the highlight area
+        return self.rect
+
+    def paint(self, painter, option, widget):
+        # Set the pen to draw a white outline with a thickness of 2 pixels
+        painter.setPen(QtGui.QPen(QtGui.QColor(255, 255, 255), 2))
+        # Draw the rectangle (highlight area) using the painter
+        painter.drawRect(self.rect)
+
+    def mousePressEvent(self, event):
+        """
+        Handle mouse press events.
+        If the left mouse button is pressed, it verifies if the highlight area has a parent item, saves the starting
+        position and size, checks if the click is within the resize area, and accepts the event.
+        For the right mouse button, the event is ignored.
+
+        Parameters:
+        event (QGraphicsSceneMouseEvent): The mouse event.
+        """
+        if event.button() == QtCore.Qt.LeftButton:
+            if self.parentItem() is None:
+                print("No target window")
+                return
+            # Save the starting position of the mouse click
+            self.startPos = event.pos()
+            # Save the starting position and size of the highlight area
+            self.startRect = self.rect
+            # Check if the mouse click is in the resize area
+            self.resizing = self.isInResizeArea(event.pos())
+            event.accept()
+        else:
+            event.ignore()
+
+    def mouseMoveEvent(self, event):
+        """
+        Handle mouse move events.
+        This method checks if the left mouse button is pressed and calculates the change in position.
+        If resizing, it adjusts the bottom-right corner of the rectangle.
+        If not resizing, it translates the entire highlight area.
+        The event is accepted if the left mouse button is pressed, otherwise it is ignored.
+
+        Parameters:
+        event (QGraphicsSceneMouseEvent): The mouse event.
+        """
+        # Check if the left mouse button is pressed
+        if event.buttons() == QtCore.Qt.LeftButton:
+            # Calculate the change in position
+            delta = event.pos() - self.startPos
+            # If resizing, adjust the bottom-right corner of the rectangle
+            if self.resizing:
+                newRect = QtCore.QRectF(self.startRect)
+                newRect.setBottomRight(newRect.bottomRight() + delta)
+                self.setRect(newRect)
+            else:
+                # If not resizing, translate the entire highlight area
+                newRect = self.startRect.translated(delta)
+                self.setRect(newRect)
+            # Accept the event
+            event.accept()
+        else:
+            # Ignore the event if the left mouse button is not pressed
+            event.ignore()
+
+    def isInResizeArea(self, pos):
+        """
+        Check if the position is in the resize area.
+
+        Parameters:
+        pos (QPointF): The position to check.
+
+        Returns:
+        bool: True if the position is in the resize area, False otherwise.
+        """
+        resizeArea = QtCore.QRectF(self.rect.bottomRight() - QtCore.QPointF(10, 10), self.rect.bottomRight())# ???
+        return resizeArea.contains(pos)
+
+    def setRect(self, rect):
+        # Cap the width and height to the dimensions of the minimap
+        minimap_width = self.parentItem().boundingRect().width()
+        minimap_height = self.parentItem().boundingRect().height()
+
+        # Ensure the rectangle does not exceed the minimap's dimensions
+        if rect.width() > minimap_width:
+            rect.setWidth(minimap_width)
+        if rect.height() > minimap_height:
+            rect.setHeight(minimap_height)
 
 
 class ViewBoxNoRightDrag(pg.ViewBox):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -458,6 +458,10 @@ class MinimapWindow(QDialog):
         # Remove all resize handles after initialization
         QtCore.QTimer.singleShot(0, lambda: [self.highlight_area.removeHandle(handle) for handle in
                                              self.highlight_area.getHandles()])
+
+
+        # Set the highlight area to cover the entire image by default
+        self.set_highlight_area(0, 0, 1, 1)
         # Add the highlight area to the viewbox
         self.viewbox.addItem(self.highlight_area)
 
@@ -514,7 +518,8 @@ class MinimapWindow(QDialog):
     def set_highlight_area(self, normalized_x, normalized_y, normalized_width, normalized_height):
         """
         Method to set the highlight area on the minimap.
-        The position and size of the rectangle are set based on the calculated normalized coordinates from the on_view method.
+        The position and size of the rectangle are set based on the calculated normalized coordinates from the
+        onViewChanged method.
 
         Parameters:
         normalized_x (float): Normalized x-coordinate for the position.
@@ -538,8 +543,8 @@ class MinimapWindow(QDialog):
             height = normalized_height * img_height
 
             # Ensure the highlight area does not exceed the boundaries of the minimap
-            x = max(0, min(x, self.viewbox.width() - width))
-            y = max(0, min(y, self.viewbox.height() - height))
+            x = max(0, x)
+            y = max(0, y)
 
             # Set the position of the rectangle  area on the minimap
             # Move the rectangle to the calculated position
@@ -549,8 +554,6 @@ class MinimapWindow(QDialog):
             # Adjust the rectangle's size to the calculated width and height
             self.highlight_area.setSize([width, height])
 
-            # Return the calculated coordinates and dimensions of the rectangle
-            return x, y, width, height
         else:
             print("Error: No image loaded in parent.")
 

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -535,8 +535,10 @@ class MinimapWindow(QDialog):
 
             # Ensure the highlight area does not exceed the boundaries of the minimap
             if x + width > img_width:
+                print("Error: Highlight area width exceeds image width.")
                 width = img_width - x
             if y + height > img_height:
+                print("Error: Highlight area height exceeds image height.")
                 height = img_height - y
 
             # Set the position of the rectangle  area on the minimap
@@ -549,6 +551,8 @@ class MinimapWindow(QDialog):
 
             # Return the calculated coordinates and dimensions of the rectangle
             return x, y, width, height
+        else:
+            print("Error: No image loaded in parent.")
 
 
     def sliderValueChanged(self, value):

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -9,7 +9,7 @@ import cv2
 import tifffile
 import logging
 import fastremap
-from PIL import Image, ImageSequence, ImageOps
+
 
 from ..io import imread, imsave, outlines_to_text, add_model, remove_model, save_rois, save_settings, save_features_csv
 from ..models import normalize_default, MODEL_DIR, MODEL_LIST_PATH, get_user_models


### PR DESCRIPTION
resolves #41 

## Description
This ticket is the second part of the previous issue 12. This PR implements the feature to add a highlight area on the minimap, which can be adjusted in size and position based on normalized coordinates calculated in Ticket #65.

## Changes

The following changes were made in **cellpose/gui/guiparts.py**:

- Added `set_highlight_area` method to the `MinimapWindow class`:
   - Calculates the position and size of the highlight area based on normalized coordinates.
   - Caps the width and height of the highlight area to ensure it does not exceed the minimap size.
   - Sets the position and size of the highlight area on the minimap.
   
- Integrated the highlight area into the minimap as a `pg.RectROI` object:
   - Created and added a rectangle highlight area to the minimap.
   - Set the highlight area with an initial position of `[0, 0]` and size `[100, 100]`, outlined in white with a 3-pixel width.

## Testing

To test the highlight area, you can change the normalized values for the coordinates and dimensions in the method call self.set_highlight_area(normalized_x, normalized_y, normalized_width, normalized_height) within the MinimapWindow(QDialog) class to draw a rectangle at the corresponding position and size.