### PR TITLE
32 Compute Features

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1309,6 +1309,11 @@ class MainW(QMainWindow):
             self.saveROIs.setEnabled(False)
 
     def toggle_save_features_csv(self):
+        """
+        Toggles the save features csv button based on the image file type.
+        If the image is a tiff or tif file, the button is enabled. Otherwise, it is disabled.
+        This method is called after a segmentation has taken place.
+        """
 
         filetype = imghdr.what(self.filename)
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -39,6 +39,8 @@ except:
 
 Horizontal = QtCore.Qt.Orientation.Horizontal
 
+import imghdr
+
 
 class Slider(QRangeSlider):
 
@@ -1278,6 +1280,7 @@ class MainW(QMainWindow):
         self.saveSet.setEnabled(False)
         self.savePNG.setEnabled(False)
         self.saveFlows.setEnabled(False)
+        self.saveFeaturesCsv.setEnabled(False)
         self.saveOutlines.setEnabled(False)
         self.saveROIs.setEnabled(False)
         self.minimapWindow.setEnabled(False)
@@ -1305,6 +1308,9 @@ class MainW(QMainWindow):
             self.saveFlows.setEnabled(False)
             self.saveOutlines.setEnabled(False)
             self.saveROIs.setEnabled(False)
+
+    def toggle_save_features_csv(self):
+        self.saveFeaturesCsv.setEnabled(True)
 
     def toggle_removals(self):
         if self.ncells > 0:

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -388,8 +388,10 @@ class MainW(QMainWindow):
         This gives us a stacked four-dimensional array with that shape shape (N, H, W, C).
         N is the number of images, H is height, W is width, C is channels (2 for LA).
         This makes it easier to extract information about the channels later on.
+
         Args:
             images (list): A list of PIL images.
+
         Returns:
             np.ndarray: A stacked four-dimensional array of the images.
         """
@@ -1313,6 +1315,12 @@ class MainW(QMainWindow):
         Toggles the save features csv button based on the image file type.
         If the image is a tiff or tif file, the button is enabled. Otherwise, it is disabled.
         This method is called after a segmentation has taken place.
+
+        Args:
+            None
+
+        Returns:
+            None
         """
 
         filetype = imghdr.what(self.filename)

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -4,7 +4,7 @@ Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer a
 
 import sys, os, pathlib, warnings, datetime, time, copy
 
-
+from PIL import Image
 from qtpy import QtGui, QtCore
 from superqt import QRangeSlider, QCollapsible
 from qtpy.QtWidgets import QScrollArea, QMainWindow, QApplication, QWidget, QScrollBar, QComboBox, QGridLayout, QPushButton, QFrame, QCheckBox, QLabel, QProgressBar, QLineEdit, QMessageBox, QGroupBox, QColorDialog

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -381,6 +381,16 @@ class MainW(QMainWindow):
                          color_bg.getchannel("B"), alpha))
             self.colored_image_stack.append(colored_image)
 
+    def convert_images_to_array(self, images):
+        # Convert each image to a numpy array
+        arrays = [np.array(image) for image in images]
+
+        # Stack all image arrays along a new axis, creating a 4D array
+        # The new array will have shape (N, H, W, C) where:
+        # N is the number of images, H is height, W is width, C is channels (2 for LA)
+        stacked_array = np.stack(arrays, axis=0)
+
+        return stacked_array
 
     def minimap_closed(self):
         """

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -4,7 +4,7 @@ Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer a
 
 import sys, os, pathlib, warnings, datetime, time, copy
 
-from PIL import Image
+
 from qtpy import QtGui, QtCore
 from superqt import QRangeSlider, QCollapsible
 from qtpy.QtWidgets import QScrollArea, QMainWindow, QApplication, QWidget, QScrollBar, QComboBox, QGridLayout, QPushButton, QFrame, QCheckBox, QLabel, QProgressBar, QLineEdit, QMessageBox, QGroupBox, QColorDialog

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -14,6 +14,7 @@ from qtpy.QtGui import QIcon, QColor
 import numpy as np
 from scipy.stats import mode
 import cv2
+import imghdr
 
 from . import guiparts, menus, io
 from .. import models, core, dynamics, version, denoise, train
@@ -38,8 +39,6 @@ except:
     SERVER_UPLOAD = False
 
 Horizontal = QtCore.Qt.Orientation.Horizontal
-
-import imghdr
 
 
 class Slider(QRangeSlider):

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1310,7 +1310,13 @@ class MainW(QMainWindow):
             self.saveROIs.setEnabled(False)
 
     def toggle_save_features_csv(self):
-        self.saveFeaturesCsv.setEnabled(True)
+
+        filetype = imghdr.what(self.filename)
+
+        if filetype in ['tiff', 'tif']:
+            self.saveFeaturesCsv.setEnabled(True)
+        else:
+            self.saveFeaturesCsv.setEnabled(False)
 
     def toggle_removals(self):
         if self.ncells > 0:

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -382,12 +382,20 @@ class MainW(QMainWindow):
             self.colored_image_stack.append(colored_image)
 
     def convert_images_to_array(self, images):
+        """
+        Convert a list of PIL images to a numpy array.
+        This gives us a stacked four-dimensional array with that shape shape (N, H, W, C).
+        N is the number of images, H is height, W is width, C is channels (2 for LA).
+        This makes it easier to extract information about the channels later on.
+        Args:
+            images (list): A list of PIL images.
+        Returns:
+            np.ndarray: A stacked four-dimensional array of the images.
+        """
         # Convert each image to a numpy array
         arrays = [np.array(image) for image in images]
 
         # Stack all image arrays along a new axis, creating a 4D array
-        # The new array will have shape (N, H, W, C) where:
-        # N is the number of images, H is height, W is width, C is channels (2 for LA)
         stacked_array = np.stack(arrays, axis=0)
 
         return stacked_array

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -172,6 +172,8 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
             parent.minimap_window_instance = guiparts.MinimapWindow(parent)
             parent.minimap_window_instance.show()
 
+        #parent.toggle_save_features_csv()
+
 
 def _initialize_images(parent, image, load_3D=False):
     """ format image for GUI """
@@ -500,6 +502,7 @@ def _load_masks(parent, filename=None):
     if parent.ncells > 0:
         parent.draw_layer()
         parent.toggle_mask_ops()
+        parent.toggle_save_features_csv()
     del masks
     gc.collect()
     parent.update_layer()
@@ -579,6 +582,7 @@ def _masks_to_gui(parent, masks, outlines=None, colors=None):
     if parent.ncells > 0:
         parent.draw_layer()
         parent.toggle_mask_ops()
+        parent.toggle_save_features_csv()
     parent.ismanual = np.zeros(parent.ncells, bool)
     parent.zdraw = list(-1 * np.ones(parent.ncells, np.int16))
 
@@ -603,9 +607,6 @@ def _save_features_csv(parent):
         return
 
     filename = parent.filename
-
-    if filename.lower().endswith(('.tif', '.tiff')):
-        parent.toggle_save_features_csv()
 
     base = os.path.splitext(filename)[0] + "_features.csv"
 

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -4,6 +4,7 @@ Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer a
 
 import os, datetime, gc, warnings, glob, shutil, copy
 from natsort import natsorted
+from PIL import Image
 import numpy as np
 import cv2
 import tifffile

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -610,7 +610,6 @@ def _save_features_csv(parent):
         stacked_images = parent.convert_images_to_array(parent.grayscale_image_stack)
         # reduction to only the relevant light intensity channel
         channels = stacked_images[:, :, :, 1]
-        print(channels)
         save_features_csv(parent.filename, parent.cellpix, channels)
     else:
         print("ERROR: cannot save features")

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -9,7 +9,7 @@ import cv2
 import tifffile
 import logging
 import fastremap
-from PIL import Image, ImageSequence, ImageOps
+
 
 from ..io import imread, imsave, outlines_to_text, add_model, remove_model, save_rois, save_settings, save_features_csv
 from ..models import normalize_default, MODEL_DIR, MODEL_LIST_PATH, get_user_models

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -610,6 +610,7 @@ def _save_features_csv(parent):
         stacked_images = parent.convert_images_to_array(parent.grayscale_image_stack)
         # reduction to only the relevant light intensity channel
         channels = stacked_images[:, :, :, 1]
+        # save the features to a CSV file using method in cellpose.io
         save_features_csv(parent.filename, parent.cellpix, channels)
     else:
         print("ERROR: cannot save features")

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -171,6 +171,8 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
             parent.minimap_window_instance = guiparts.MinimapWindow(parent)
             parent.minimap_window_instance.show()
 
+        parent.saveFeaturesCsv.setEnabled(False)
+
 
 def _initialize_images(parent, image, load_3D=False):
     """ format image for GUI """

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -589,8 +589,7 @@ def _save_features_csv(parent):
     if parent.NZ == 1:
         print("GUI_INFO: saving features to CSV file")
         # this gives us the channels that are currently loaded
-        channels = [parent.ChannelChoose[0].currentText(), parent.ChannelChoose[1].currentText()]
-        # apparently not lol
+        channels = parent.grayscale_image_stack
         save_features_csv(parent.filename, parent.cellpix, channels)
     else:
         print("ERROR: cannot save features")

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -8,7 +8,6 @@ import numpy as np
 import cv2
 import tifffile
 import logging
-import imghdr
 import fastremap
 from PIL import Image, ImageSequence, ImageOps
 
@@ -171,8 +170,6 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
         else:
             parent.minimap_window_instance = guiparts.MinimapWindow(parent)
             parent.minimap_window_instance.show()
-
-        #parent.toggle_save_features_csv()
 
 
 def _initialize_images(parent, image, load_3D=False):
@@ -502,6 +499,7 @@ def _load_masks(parent, filename=None):
     if parent.ncells > 0:
         parent.draw_layer()
         parent.toggle_mask_ops()
+        # features can only be saved if masks are loaded
         parent.toggle_save_features_csv()
     del masks
     gc.collect()
@@ -582,6 +580,7 @@ def _masks_to_gui(parent, masks, outlines=None, colors=None):
     if parent.ncells > 0:
         parent.draw_layer()
         parent.toggle_mask_ops()
+        # features can only be saved if masks are loaded
         parent.toggle_save_features_csv()
     parent.ismanual = np.zeros(parent.ncells, bool)
     parent.zdraw = list(-1 * np.ones(parent.ncells, np.int16))

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -587,6 +587,7 @@ def _masks_to_gui(parent, masks, outlines=None, colors=None):
     else:
         parent.ViewDropDown.setCurrentIndex(0)
 
+
 def _save_features_csv(parent):
     """
     Saves features to CSV if dataset is 2D.
@@ -605,8 +606,11 @@ def _save_features_csv(parent):
     # check if the dataset is 2D (NZ == 1 implies a single z-layer)
     if parent.NZ == 1:
         print("GUI_INFO: saving features to CSV file")
-        # this gives us the channels that are currently loaded
-        channels = parent.grayscale_image_stack
+        # this gives us the channels that are currently loaded by converting the images to an array
+        stacked_images = parent.convert_images_to_array(parent.grayscale_image_stack)
+        # reduction to only the relevant light intensity channel
+        channels = stacked_images[:, :, :, 1]
+        print(channels)
         save_features_csv(parent.filename, parent.cellpix, channels)
     else:
         print("ERROR: cannot save features")

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -588,7 +588,10 @@ def _save_features_csv(parent):
     # check if the dataset is 2D (NZ == 1 implies a single z-layer)
     if parent.NZ == 1:
         print("GUI_INFO: saving features to CSV file")
-        save_features_csv(parent.filename)
+        # this gives us the channels that are currently loaded
+        channels = [parent.ChannelChoose[0].currentText(), parent.ChannelChoose[1].currentText()]
+        # apparently not lol
+        save_features_csv(parent.filename, parent.cellpix, channels)
     else:
         print("ERROR: cannot save features")
 

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -8,6 +8,7 @@ import numpy as np
 import cv2
 import tifffile
 import logging
+import imghdr
 import fastremap
 from PIL import Image, ImageSequence, ImageOps
 
@@ -602,7 +603,12 @@ def _save_features_csv(parent):
         return
 
     filename = parent.filename
+
+    if filename.lower().endswith(('.tif', '.tiff')):
+        parent.toggle_save_features_csv()
+
     base = os.path.splitext(filename)[0] + "_features.csv"
+
     # check if the dataset is 2D (NZ == 1 implies a single z-layer)
     if parent.NZ == 1:
         print("GUI_INFO: saving features to CSV file")

--- a/cellpose/gui/menus.py
+++ b/cellpose/gui/menus.py
@@ -81,6 +81,7 @@ def mainmenu(parent):
     This adds a new menu item for saving features as a .csv file. 
     The user can activate this function to export specific data directly from the GUI.
     The function `_save_features_as_csv` from the `io` module is called when the user clicks on the menu item.
+    It is disabled by default and only activated if an image is segmented and of the type tif/tiff.
     """
     parent.saveFeaturesCsv = QAction("Save Features as .&csv", parent)
     parent.saveFeaturesCsv.setShortcut("Ctrl+Shift+C")

--- a/cellpose/gui/menus.py
+++ b/cellpose/gui/menus.py
@@ -86,7 +86,7 @@ def mainmenu(parent):
     parent.saveFeaturesCsv.setShortcut("Ctrl+Shift+C")
     parent.saveFeaturesCsv.triggered.connect(lambda: io._save_features_csv(parent))
     file_menu.addAction(parent.saveFeaturesCsv)
-    parent.saveFeaturesCsv.setEnabled(True)
+    parent.saveFeaturesCsv.setEnabled(False)
 
     """
     This creates a new menu item for the minimap that the user can activate.

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -604,8 +604,10 @@ def save_features_csv(file_name, cellpix, channels):
 
         # Calculate the feature for each channel
         for j in range(num_channels):
+
             # Sum the marker intensities for the current cell in the current channel
             marker_intensity_sum = np.sum(channels[j][cell_mask])
+            # has to be fixed yet
 
             # Calculate the average marker intensity for the current cell in the current channel
             features[i, j] = marker_intensity_sum / num_pixels

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -594,6 +594,7 @@ def save_features_csv(file_name, cellpix, channels):
     for i, cell_id in enumerate(cell_ids):
         # Create a mask for the current cell
         cell_mask = cellpix == cell_id
+        # Returns a boolean matrix indicating the location of the current cell
 
         # Count the number of pixels in the current cell
         num_pixels = np.sum(cell_mask)
@@ -606,8 +607,7 @@ def save_features_csv(file_name, cellpix, channels):
         for j in range(num_channels):
 
             # Sum the marker intensities for the current cell in the current channel
-            marker_intensity_sum = np.sum(channels[j][cell_mask])
-            # has to be fixed yet
+            marker_intensity_sum = np.sum(channels[j] * cell_mask)
 
             # Calculate the average marker intensity for the current cell in the current channel
             features[i, j] = marker_intensity_sum / num_pixels

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -579,7 +579,7 @@ def save_features_csv(file_name, cellpix, channels):
     if os.path.exists(file_name):
         os.remove(file_name)
 
-        # Get unique cell ids (excluding background which is assumed to be 0)
+    # Get unique cell ids (excluding background which is assumed to be 0)
     cell_ids = np.unique(cellpix)
     cell_ids = cell_ids[cell_ids != 0]
 

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -571,8 +571,8 @@ def save_features_csv(file_name, cellpix, channels):
 
     Args:
         file_name (str): Target CSV file name
-        cellpix: np.ndarray, the mask array where each cell has a unique ID
-        channels: list of np.ndarray, the list of channel images
+        cellpix (np.ndarray): Mask array where each cell has a unique ID
+        channels (ist of np.ndarray): List of channel images
 
     Returns:
         None

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -69,8 +69,6 @@ def logger_setup():
     return logger, log_file
 
 
-import numpy as np
-import csv
 
 from . import utils, plot, transforms
 
@@ -566,11 +564,15 @@ def masks_flows_to_seg(images, masks, flows, file_names, diams=30., channels=Non
 
 def save_features_csv(file_name, cellpix, channels):
     """
-    Save features to .csv file and remove if it already exists
+    This method saves the features of a segmentation to .csv file and replaces the old one if it exists.
+    It is saved in the folder containing the current image.
+    The features are the average marker intensity for each cell in each channel.
+    They are calculates in form of a matrix: Rows represent cells, columns represent channels.
+
     Args:
         file_name (str): Target CSV file name
-        cellpix: np.ndarray, the mask array where each cell has a unique ID.
-        channels: list of np.ndarray, the list of channel images.
+        cellpix: np.ndarray, the mask array where each cell has a unique ID
+        channels: list of np.ndarray, the list of channel images
 
     Returns:
         None


### PR DESCRIPTION
resolves #32 

## The feature matrix is calculated correctly for tiff/tif images and saved in a .csv file

The following changes were implemented:
- the button responsible for saving the segmentation in **cellpose.gui/menus.py** was adapted to be disabled by default to prevent error messages in case of it being used in inadequate situations
- method `toggle_save_features_csv` was created in **cellpose/gui/gui.py** to control the menu button:
   - button is only enabled if the image is of the type .tif or .tiff
   - method is called in **cellpose/gui/io.py**; therefore the button is also only enabled if the picture has already been segmented
   - if a new image is loaded, the button is disabled again in the existing function `_load_image` in **cellpose/gui/io.py** to prevent it staying active
- method `convert_images_to_array` was created in **cellpose/gui/gui.py** to facilitate the extraction of information about the channels:
   - returns four-dimensional `stacked_array`, with the intensity included in the fourth dimension
   - this is used in **cellpose/gui/io.py** to transform `parent.grayscale_image_stack`, where the current image is stored
- in the existing method `_save_features_csv` in **cellpose/gui/io.py**, the indentically named method in **cellpose/io.py** is now called with two additional arguments:
   - `cellpix`: This stores the masks of the cells and therefore provides an overview over the segmented cells
   - `channels`: This is the information extracted using `convert_images_to_array` and contains the different segmentations depending on the channels. In the fourth dimension, only the second column is used, for those contain the relevant information 
- existing method `save_features_csv` in **cellpose/io.py** was adapted:
   - the individual cells are saved in `cell_ids`
   - the number of cells found is saved in `num_cells`
   - the number of channels is saved in `num_channels`
   - a matrix called `features` is initialized
   - this matrix is filled using two for loops:
      - the outer loop iterates over the `cell_id` and creates a boolean matrix `cell_mask` that saves for every pixel whether it is part of the current cell
      - the number of pixels is saved in `num_pixels`
      - the inner loop iterates over the channels `num_channels`
         - the marker intensity for the cells is calculated by multiplying the matrix for the respective channel (`channels[j]`) with the one indicating the current cell (`cell_mask`)
         - this is divided by the number of pixels and entered in the feature-matrix
   - the rows of the final feature-matrix contain the cells, the columns the channels
   - finally, this matrix is saved in a .csv file

This PR combines the code from #58 and the information from the research task #64.
The functionality is currently only given for tiff/tif images, for this is the most common use case. Future extensions of this are conceivable. However, this would need a more general conversion of image arrays which is not yet given.

### Information for testing
For testing, I recommend using a relatively small tif image, since bigger images can lead to a long runtime. You are welcome to try it using bigger pictures, but at least my laptop sadly can't handle the segmentation leading to the program crashing.
 You can use the button in the file menu once you have segmented the picture by clicking on the run cyto3 button:
![image](https://github.com/user-attachments/assets/5a15ec89-7fcd-45ba-9cc5-74e9f304f801)
The button in the file menu should only be usable after the segmentation. Prior to that, you should not be able to click on it (depending on your system it might look grey or somewhat blurry). In my case, it looks like this, it might be more clear on Mac.
![image](https://github.com/user-attachments/assets/c7175b9f-67ad-407a-a2b3-eaac0d177681)

### Showcase
For the example_tif_image.tif file _(on the right)_ that was sent in the Discord server, the resulting matrix in the created file _(on the left)_ should look like this:
![image](https://github.com/user-attachments/assets/2184cb4a-6cd8-4473-be30-f6c5984805c2)
(If you can't find the file I can send it to you of course.)

### Interpretation
The values in the matrix should be between 0 and 255. Bigger values indicate a higher intensity. 
In the example above we could therefore deduce that channel 1 and channel 5 are relatively bright for the given cells.