### PR TITLE
42 dynamically adjusting highlight area minimap orientation

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -4,7 +4,6 @@ Copyright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer a
 
 import sys, os, pathlib, warnings, datetime, time, copy
 
-from PIL import Image
 from qtpy import QtGui, QtCore
 from superqt import QRangeSlider, QCollapsible
 from qtpy.QtWidgets import QScrollArea, QMainWindow, QApplication, QWidget, QScrollBar, QComboBox, QGridLayout, QPushButton, QFrame, QCheckBox, QLabel, QProgressBar, QLineEdit, QMessageBox, QGroupBox, QColorDialog
@@ -476,6 +475,9 @@ class MainW(QMainWindow):
             # Calculate the normalized dimensions
             normalized_width = width / img_width
             normalized_height = height / img_height
+
+            # Set the highlight area in the minimap window
+            self.minimap_window_instance.set_highlight_area(normalized_x[0], normalized_y[0], normalized_width, normalized_height)
 
             return normalized_x, normalized_y, normalized_width, normalized_height
 

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -9,7 +9,7 @@ import cv2
 import tifffile
 import logging
 import fastremap
-from PIL import Image, ImageSequence, ImageOps
+
 
 from ..io import imread, imsave, outlines_to_text, add_model, remove_model, save_rois, save_settings, save_features_csv
 from ..models import normalize_default, MODEL_DIR, MODEL_LIST_PATH, get_user_models


### PR DESCRIPTION
Solves #42 

### Description

This ticket brings together the functions in tickets #40 and #41, so that a rectangle is drawn on the minimap that highlights the current view region of an image in the main window.

### Changes

The function set_highlight_area() of the MInimapWindow class, which draws a rectangle on the minimap according to normalized coordinates and dimensions, is called at the end of onViewChanged() in the mainW class, which is updated every time the view region of the main window is updated. If one moves across the image or zooms in or out, the minimap's highlight area changes to reflect the actual viewbox area.

### Testing

One can test this simply by loading and image and trying different zoom levels and view regions.
