### PR TITLE
#52_54_sliders_and_buttons_functionality

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -396,19 +396,54 @@ class MainW(QMainWindow):
         for i in range(len(self.grayscale_image_stack)):
             self.colors_stack.append(colors[i % len(colors)])
 
-    def generate_color_image_stack(self):
-        for i in range(len(self.grayscale_image_stack)):
-            color = self.colors_stack[i]
+    def initialize_color_image_stack(self):
+            self.colored_image_stack = []
+            for i in range(len(self.grayscale_image_stack)):
+                color = self.colors_stack[i]
 
-            alpha = self.grayscale_image_stack[i].getchannel("A")
-            color_bg = Image.new("RGB", self.grayscale_image_stack[i].size,
-                                 color)
-            colored_image = Image.merge(
-                "RGBA", (color_bg.getchannel("R"), color_bg.getchannel("G"),
-                         color_bg.getchannel("B"), alpha))
-            self.colored_image_stack.append(colored_image)
+                alpha = self.grayscale_image_stack[i].getchannel("A")
+                color_bg = Image.new("RGB", self.grayscale_image_stack[i].size,
+                                     color)
+                colored_image = Image.merge(
+                    "RGBA", (color_bg.getchannel("R"), color_bg.getchannel("G"),
+                             color_bg.getchannel("B"), alpha))
+                self.colored_image_stack.append(colored_image)
+                # colored_image.show()
+
+    def generate_color_image_stack(self):
+        """
+        Generate a color image stack by overlaying the grayscale images with the corresponding colors from the colors stack.
+
+        This function iterates over the grayscale image stack and the colors stack simultaneously. For each pair of grayscale image and color, it creates a new RGBA image by overlaying the grayscale image with the color. The alpha channel of the grayscale image is used as the transparency level for the overlay. The resulting colored image is then assigned to the corresponding position in the colored image stack.
+
+        Parameters:
+            None
+
+        Returns:
+            None
+        """
+        for i in range(len(self.colored_image_stack)):
+            grayscale_image = self.grayscale_image_stack[i]
+
+            # Check if the grayscale image has an alpha channel
+            if grayscale_image.mode != "RGBA":
+                # If not, add an alpha channel
+                grayscale_image = grayscale_image.convert("RGBA")
+
+            alpha = grayscale_image.getchannel("A")
+
+            # Create a new RGB image with the background color
+            color_bg = Image.new("RGB", grayscale_image.size, self.colors_stack[i])
+            print(f"Image {i} - Color: {self.colors_stack[i]}")
+
+            # Combine the color background with the alpha channel
+            colored_image = Image.merge("RGBA", (
+                color_bg.getchannel("R"), color_bg.getchannel("G"), color_bg.getchannel("B"), alpha))
+
+            self.colored_image_stack[i] = colored_image
 
         self.combine_images()
+        self.update_plot()
 
     def combine_images(self):
         """

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -14,7 +14,7 @@ from PIL import Image
 import numpy as np
 from scipy.stats import mode
 import cv2
-from webcolors import rgb_to_hex
+
 
 from . import guiparts, menus, io
 from .. import models, core, dynamics, version, denoise, train
@@ -144,6 +144,18 @@ def make_cmap(cm=0):
     color = color.astype(np.uint8)
     cmap = pg.ColorMap(pos=np.linspace(0.0, 255, 256), color=color)
     return cmap
+
+def rgb_to_hex(rgb_tuple):
+    """
+    Converts an RGB tuple to a hex color string.
+
+    Args:
+        rgb_tuple (tuple): The RGB tuple (e.g., (255, 0, 0) for red).
+
+    Returns:
+        str: The hex color string (e.g., '#ff0000' for red).
+    """
+    return '#{:02x}{:02x}{:02x}'.format(rgb_tuple[0], rgb_tuple[1], rgb_tuple[2])
 
 
 def run(image=None):

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -121,12 +121,12 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
 
             # Initialize the colors and colored_image_stack attributes
             parent.color_initialization()
-            parent.generate_color_image_stack()
+            parent.initialize_color_image_stack()
 
             # Initialize the Buttons and sliders for multi-layer TIFF
             num_layers = len(grayscale_image_stack)
-            is_tiff = True
-            parent.generate_multi_channel_ui(num_layers, is_tiff)
+            parent.tiff_loaded = True
+            parent.generate_multi_channel_ui(num_layers, True)
             print(f"GUI_INFO: Tiff loaded with {len(grayscale_image_stack)} layers")
 
     manual_file = os.path.splitext(filename)[0] + "_seg.npy"


### PR DESCRIPTION
Implemented changes to solve #52 and #54.

The following things were changed to achieve that the on-off buttons and the sliders work for multi layered tiffs (multichannel):

- Sliders were set to be initially enabled
- New stack self.combined_images hold the combined image of the multi layered stacks to show
- New method: self.combine_images() combines the layers from the colored stack, adds a black background
- the on_off buttons have an index to adress the right layer
- new method: self_toggle_channel_on_off connected to the on_off_buttons toggles the corresponding layer on and off when the button is clicked
- added boolean that shows if tiff is loaded
- changed update_plot method for only for visualization (will be modified)
- changed level_change method to treat tiff case for sliders
- added method adjust_contrast: adjusts the contrast of image based on upper and lower bounds
- added method adjust_channel_bounds(self, channel, bounds): adjusts contrast via adjust_contrast and then re-combines image

To test this: start cellpose, load a multi layered tiff and use buttons and sliders (see if they work)